### PR TITLE
事務所名を田中行政書士事務所からフォルティア行政書士事務所に統一

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -8,7 +8,7 @@ export default function About() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">田中行政書士事務所</h1>
+              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
             </div>
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-600 hover:text-gray-900">
@@ -32,7 +32,7 @@ export default function About() {
       <section className="bg-blue-600 text-white py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="text-4xl font-bold mb-4">事務所概要</h1>
-          <p className="text-xl">田中行政書士事務所について</p>
+          <p className="text-xl">フォルティア行政書士事務所について</p>
         </div>
       </section>
 
@@ -163,7 +163,7 @@ export default function About() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">田中行政書士事務所</h3>
+              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />
@@ -187,7 +187,7 @@ export default function About() {
             </div>
           </div>
           <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-            <p>&copy; 2024 田中行政書士事務所. All rights reserved.</p>
+            <p>&copy; 2024 フォルティア行政書士事務所. All rights reserved.</p>
           </div>
         </div>
       </footer>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -8,7 +8,7 @@ export default function Contact() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">田中行政書士事務所</h1>
+              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
             </div>
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-600 hover:text-gray-900">
@@ -234,7 +234,7 @@ export default function Contact() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">田中行政書士事務所</h3>
+              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />
@@ -258,7 +258,7 @@ export default function Contact() {
             </div>
           </div>
           <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-            <p>&copy; 2024 田中行政書士事務所. All rights reserved.</p>
+            <p>&copy; 2024 フォルティア行政書士事務所. All rights reserved.</p>
           </div>
         </div>
       </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士</h1>
+              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
             </div>
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-600 hover:text-gray-900">
@@ -438,7 +438,7 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士</h3>
+              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />
@@ -462,7 +462,7 @@ export default function Home() {
             </div>
           </div>
           <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-            <p>&copy; 2024 フォルティア行政書士. All rights reserved.</p>
+            <p>&copy; 2024 フォルティア行政書士事務所. All rights reserved.</p>
           </div>
         </div>
       </footer>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -8,7 +8,7 @@ export default function Services() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">田中行政書士事務所</h1>
+              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
             </div>
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-600 hover:text-gray-900">
@@ -270,7 +270,7 @@ export default function Services() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">田中行政書士事務所</h3>
+              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />
@@ -294,7 +294,7 @@ export default function Services() {
             </div>
           </div>
           <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-            <p>&copy; 2024 田中行政書士事務所. All rights reserved.</p>
+            <p>&copy; 2024 フォルティア行政書士事務所. All rights reserved.</p>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
- ヘッダー、フッター、ページタイトルの事務所名を変更
- 全ページで一貫した事務所名表記に統一

🤖 Generated with [Claude Code](https://claude.ai/code)