### PR TITLE
フッターの事務所名にホームページへのリンクを追加

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -128,7 +128,9 @@ export default function About() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -283,7 +283,9 @@ export default async function BlogDetailPage({ params }: PageProps) {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -308,7 +308,9 @@ export default async function BlogPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -234,7 +234,9 @@ export default function Contact() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -174,7 +174,9 @@ export default async function NewsDetailPage({ params }: PageProps) {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -20,7 +20,7 @@ export default async function NewsPage() {
       title: "事務所開設のお知らせ",
       slug: { current: "jimusho-kaisetsu-oshirase" },
       publishedAt: "2025-07-07",
-      excerpt: "フォルティア行政書士事務所事務所を開設いたしました",
+      excerpt: "フォルティア行政書士事務所を開設いたしました",
       category: "important",
       featured: true
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -582,7 +582,9 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -270,7 +270,9 @@ export default function Services() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -251,7 +251,9 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -239,7 +239,9 @@ export default async function TestimonialsPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
-              <h3 className="text-lg font-semibold mb-4">フォルティア行政書士事務所</h3>
+              <Link href="/">
+                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+              </Link>
               <p className="text-gray-400">
                 〒100-0001<br />
                 東京都千代田区千代田1-1-1<br />


### PR DESCRIPTION
- 全ページのフッターで「フォルティア行政書士事務所」をクリック可能に
- ホームページ（/）に戻る機能を実装
- ホバー効果とカーソルポインターでユーザビリティを向上
- news/page.tsxの重複文字「事務所事務所」を修正

🤖 Generated with [Claude Code](https://claude.ai/code)