### PR TITLE
フッターリンクのスタイルを改善してより分かりやすく

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -129,7 +129,7 @@ export default function About() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -284,7 +284,7 @@ export default async function BlogDetailPage({ params }: PageProps) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -309,7 +309,7 @@ export default async function BlogPage() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -235,7 +235,7 @@ export default function Contact() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -175,7 +175,7 @@ export default async function NewsDetailPage({ params }: PageProps) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -583,7 +583,7 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -271,7 +271,7 @@ export default function Services() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -252,7 +252,7 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -240,7 +240,7 @@ export default async function TestimonialsPage() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-lg font-semibold mb-4 hover:text-blue-300 transition-colors cursor-pointer underline-offset-2 hover:underline">フォルティア行政書士事務所</h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />


### PR DESCRIPTION
- ホバー時の色をblue-300に変更してリンクであることを明確化
- hover:underlineを追加してアンダーラインでリンクを示す
- underline-offset-2でアンダーラインの位置を調整

🤖 Generated with [Claude Code](https://claude.ai/code)