### PR TITLE
ロゴデザインを「行政書士法人ストレート」スタイルに変更

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -8,7 +8,10 @@ export default function About() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+              <h1 className="text-xl font-bold">
+                <span className="text-blue-600">フォルティア</span>
+                <span className="text-gray-600 ml-1">行政書士事務所</span>
+              </h1>
             </div>
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-600 hover:text-gray-900">
@@ -129,7 +132,7 @@ export default function About() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -125,7 +125,7 @@ export default async function BlogDetailPage({ params }: PageProps) {
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
               <Link href="/">
-                <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+                <h1 className="text-xl font-bold"><span className="text-blue-600">フォルティア</span><span className="text-gray-600 ml-1">行政書士事務所</span></h1>
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
@@ -284,7 +284,7 @@ export default async function BlogDetailPage({ params }: PageProps) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -85,7 +85,7 @@ export default async function BlogPage() {
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
               <Link href="/">
-                <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+                <h1 className="text-xl font-bold"><span className="text-blue-600">フォルティア</span><span className="text-gray-600 ml-1">行政書士事務所</span></h1>
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
@@ -309,7 +309,7 @@ export default async function BlogPage() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -8,7 +8,10 @@ export default function Contact() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+              <h1 className="text-xl font-bold">
+                <span className="text-blue-600">フォルティア</span>
+                <span className="text-gray-600 ml-1">行政書士事務所</span>
+              </h1>
             </div>
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-600 hover:text-gray-900">
@@ -235,7 +238,7 @@ export default function Contact() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -61,7 +61,7 @@ export default async function NewsDetailPage({ params }: PageProps) {
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
               <Link href="/">
-                <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+                <h1 className="text-xl font-bold"><span className="text-blue-600">フォルティア</span><span className="text-gray-600 ml-1">行政書士事務所</span></h1>
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
@@ -175,7 +175,7 @@ export default async function NewsDetailPage({ params }: PageProps) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -34,7 +34,7 @@ export default async function NewsPage() {
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
               <Link href="/">
-                <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+                <h1 className="text-xl font-bold"><span className="text-blue-600">フォルティア</span><span className="text-gray-600 ml-1">行政書士事務所</span></h1>
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,10 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+              <h1 className="text-xl font-bold">
+                <span className="text-blue-600">フォルティア</span>
+                <span className="text-gray-600 ml-1">行政書士事務所</span>
+              </h1>
             </div>
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-600 hover:text-gray-900">
@@ -615,7 +618,7 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -8,7 +8,7 @@ export default function Services() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+              <h1 className="text-xl font-bold"><span className="text-blue-600">フォルティア</span><span className="text-gray-600 ml-1">行政書士事務所</span></h1>
             </div>
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-600 hover:text-gray-900">
@@ -321,7 +321,7 @@ export default function Services() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -84,7 +84,7 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
               <Link href="/">
-                <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+                <h1 className="text-xl font-bold"><span className="text-blue-600">フォルティア</span><span className="text-gray-600 ml-1">行政書士事務所</span></h1>
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
@@ -252,7 +252,7 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -77,7 +77,7 @@ export default async function TestimonialsPage() {
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
               <Link href="/">
-                <h1 className="text-2xl font-bold text-gray-900">フォルティア行政書士事務所</h1>
+                <h1 className="text-xl font-bold"><span className="text-blue-600">フォルティア</span><span className="text-gray-600 ml-1">行政書士事務所</span></h1>
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
@@ -240,7 +240,7 @@ export default async function TestimonialsPage() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div>
               <Link href="/">
-                <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">フォルティア行政書士事務所</h3>
+                <h3 className="text-base font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer"><span className="text-blue-400">フォルティア</span><span className="text-gray-300 ml-1">行政書士事務所</span></h3>
               </Link>
               <p className="text-gray-400">
                 〒100-0001<br />


### PR DESCRIPTION
- 「フォルティア」部分を青色に変更（ヘッダー: text-blue-600、フッター: text-blue-400）
- 「行政書士事務所」部分をグレー色に変更（ヘッダー: text-gray-600、フッター: text-gray-300）
- ロゴサイズを縮小（ヘッダー: text-xl、フッター: text-base）
- 全ページ（10ページ）のヘッダーとフッターに適用
- モダンでプロフェッショナルなデザインに統一

🤖 Generated with [Claude Code](https://claude.ai/code)