### PR TITLE
Remove Home navigation tab from global menu

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -14,9 +14,6 @@ export default function About() {
               </h1>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-blue-600 font-semibold">
                 事務所概要
               </Link>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -129,9 +129,6 @@ export default async function BlogDetailPage({ params }: PageProps) {
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -89,9 +89,6 @@ export default async function BlogPage() {
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -14,9 +14,6 @@ export default function Contact() {
               </h1>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -65,9 +65,6 @@ export default async function NewsDetailPage({ params }: PageProps) {
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -38,9 +38,6 @@ export default async function NewsPage() {
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,9 +14,6 @@ export default function Home() {
               </h1>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -11,9 +11,6 @@ export default function Services() {
               <h1 className="text-xl font-bold"><span className="text-gray-600">フォルティア</span><span className="text-gray-600 ml-1">行政書士事務所</span></h1>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -88,9 +88,6 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -81,9 +81,6 @@ export default async function TestimonialsPage() {
               </Link>
             </div>
             <nav className="hidden md:flex space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>


### PR DESCRIPTION
- Removed "ホーム" (Home) links from all page navigation headers
- Simplified navigation menu structure
- Logo click provides home navigation functionality
- Cleaner, more focused navigation experience

🤖 Generated with [Claude Code](https://claude.ai/code)