### PR TITLE
グローバルメニューからホームタブを削除

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,9 +14,6 @@ export default function Home() {
               </h1>
             </div>
             <nav className="hidden md:flex items-center space-x-8">
-              <Link href="/" className="text-gray-600 hover:text-gray-900">
-                ホーム
-              </Link>
               <Link href="/about" className="text-gray-600 hover:text-gray-900">
                 事務所概要
               </Link>


### PR DESCRIPTION
- ナビゲーションメニューから「ホーム」リンクを削除
- ロゴクリックでホームに戻れるため重複を解消

🤖 Generated with [Claude Code](https://claude.ai/code)