### PR TITLE
事務所情報に設立日を追加

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -52,6 +52,13 @@ export default function About() {
               <div className="bg-white p-8 rounded-lg shadow-sm">
                 <div className="space-y-6">
                   <div>
+                    <h3 className="text-lg font-semibold mb-2">設立日</h3>
+                    <p className="text-gray-700">
+                      2014年
+                    </p>
+                  </div>
+                  
+                  <div>
                     <h3 className="text-lg font-semibold mb-2">所在地</h3>
                     <p className="text-gray-700">
                       〒100-0001<br />


### PR DESCRIPTION
- aboutページの事務所情報欄に設立日の項目を追加
- 設立日: 2014年を記載

🤖 Generated with [Claude Code](https://claude.ai/code)