### PR TITLE
メンバー紹介セクションを追加

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -152,8 +152,8 @@ export default function About() {
           <h2 className="text-3xl font-bold text-gray-900 text-center mb-12">メンバー紹介</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12">
             {members.map((member) => (
-              <div key={member.id} className="group">
-                <div className="bg-gray-50 rounded-lg p-6 hover:shadow-lg transition-shadow">
+              <div key={member.id} className="group h-full">
+                <div className="bg-gray-50 rounded-lg p-6 hover:shadow-lg transition-shadow h-full flex flex-col">
                   {/* メンバー写真 - 正方形 */}
                   <div className="mb-4 relative">
                     <div className="w-full aspect-square bg-gray-200 rounded-lg overflow-hidden">
@@ -167,7 +167,7 @@ export default function About() {
                     {/* プラスボタン - 写真の右下に配置 */}
                     <button
                       onClick={() => toggleMember(member.id)}
-                      className="absolute bottom-2 right-2 w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center hover:bg-blue-700 transition-all shadow-lg"
+                      className="absolute bottom-2 right-2 w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center hover:bg-blue-700 transition-all shadow-lg z-10"
                       aria-label={`${member.name}の詳細を${expandedMember === member.id ? '閉じる' : '開く'}`}
                     >
                       <svg 
@@ -184,14 +184,16 @@ export default function About() {
                   {/* 名前 */}
                   <h3 className="text-xl font-semibold text-gray-900 text-center mb-3">{member.name}</h3>
                   
-                  {/* 自己紹介（展開時） */}
-                  <div className={`overflow-hidden transition-all duration-500 ${
-                    expandedMember === member.id ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
-                  }`}>
-                    <div className="pt-4 border-t border-gray-200">
-                      <p className="text-gray-600 text-sm leading-relaxed">
-                        {member.introduction}
-                      </p>
+                  {/* 自己紹介コンテナ - 常に存在 */}
+                  <div className="flex-1">
+                    <div className={`transition-all duration-500 ${
+                      expandedMember === member.id ? 'opacity-100' : 'opacity-0 invisible'
+                    }`}>
+                      <div className="border-t border-gray-200 pt-4">
+                        <p className="text-gray-600 text-sm leading-relaxed">
+                          {member.introduction}
+                        </p>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,55 @@
+"use client";
+
 import Link from "next/link";
 import Header from "@/components/Header";
+import { useState } from "react";
 
 export default function About() {
+  const [expandedMember, setExpandedMember] = useState<number | null>(null);
+
+  const members = [
+    {
+      id: 1,
+      name: "山田 花子",
+      photo: "/member1.jpg",
+      introduction: "行政書士として10年の経験があります。主に建設業許可や産業廃棄物処理業許可を担当しています。お客様の事業がスムーズに進むよう、全力でサポートいたします。"
+    },
+    {
+      id: 2,
+      name: "佐藤 一郎",
+      photo: "/member2.jpg",
+      introduction: "相続・遺言の専門家として、多くのご家族の大切な手続きをお手伝いしてきました。分かりやすい説明と親身な対応を心がけています。"
+    },
+    {
+      id: 3,
+      name: "高橋 美咲",
+      photo: "/member3.jpg",
+      introduction: "外国人の在留資格申請を主に担当しています。国際結婚や就労ビザなど、複雑な手続きも丁寧にサポートいたします。"
+    },
+    {
+      id: 4,
+      name: "渡辺 健太",
+      photo: "/member4.jpg",
+      introduction: "会社設立・法人設立のサポートを専門としています。起業家の皆様の夢の実現に向けて、設立から運営まで幅広くお手伝いします。"
+    },
+    {
+      id: 5,
+      name: "木村 さくら",
+      photo: "/member5.jpg",
+      introduction: "契約書作成や各種法務書類の作成を担当しています。正確で分かりやすい書類作成を心がけ、お客様の権利を守ります。"
+    },
+    {
+      id: 6,
+      name: "中村 大輔",
+      photo: "/member6.jpg",
+      introduction: "自動車関連業務を中心に、運送業許可や車庫証明など幅広く対応しています。迅速な手続きでお客様のビジネスをサポートします。"
+    }
+  ];
+
+  const toggleMember = (id: number) => {
+    setExpandedMember(expandedMember === id ? null : id);
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
@@ -94,6 +142,57 @@ export default function About() {
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Members Section */}
+      <section className="py-16 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl font-bold text-gray-900 text-center mb-12">メンバー紹介</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {members.map((member) => (
+              <div key={member.id} className="text-center">
+                {/* メンバー写真 */}
+                <div className="mb-4">
+                  <div className="w-48 h-48 mx-auto bg-gray-200 rounded-full overflow-hidden">
+                    <img 
+                      src={member.photo} 
+                      alt={member.name}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                </div>
+                
+                {/* 名前とプラスボタン */}
+                <div className="flex items-center justify-center gap-2 mb-4">
+                  <h3 className="text-lg font-semibold">{member.name}</h3>
+                  <button
+                    onClick={() => toggleMember(member.id)}
+                    className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors"
+                    aria-label={`${member.name}の詳細を${expandedMember === member.id ? '閉じる' : '開く'}`}
+                  >
+                    <svg 
+                      className={`w-4 h-4 transition-transform ${expandedMember === member.id ? 'rotate-45' : ''}`} 
+                      fill="none" 
+                      stroke="currentColor" 
+                      viewBox="0 0 24 24"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                    </svg>
+                  </button>
+                </div>
+                
+                {/* 自己紹介（展開時） */}
+                <div className={`overflow-hidden transition-all duration-300 ${
+                  expandedMember === member.id ? 'max-h-40' : 'max-h-0'
+                }`}>
+                  <p className="text-gray-600 text-sm px-4">
+                    {member.introduction}
+                  </p>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </section>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -167,11 +167,11 @@ export default function About() {
                     {/* プラスボタン - 写真の右下に配置 */}
                     <button
                       onClick={() => toggleMember(member.id)}
-                      className="absolute bottom-2 right-2 w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center hover:bg-blue-700 transition-all shadow-lg"
+                      className="absolute bottom-2 right-2 w-8 h-8 bg-gray-700 text-white rounded-full flex items-center justify-center hover:bg-gray-800 transition-all shadow-lg"
                       aria-label={`${member.name}の詳細を${expandedMember === member.id ? '閉じる' : '開く'}`}
                     >
                       <svg 
-                        className={`w-5 h-5 transition-transform duration-300 ${expandedMember === member.id ? 'rotate-45' : ''}`} 
+                        className={`w-4 h-4 transition-transform duration-300 ${expandedMember === member.id ? 'rotate-45' : ''}`} 
                         fill="none" 
                         stroke="currentColor" 
                         viewBox="0 0 24 24"

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -150,46 +150,50 @@ export default function About() {
       <section className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-gray-900 text-center mb-12">メンバー紹介</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12">
             {members.map((member) => (
-              <div key={member.id} className="text-center">
-                {/* メンバー写真 */}
-                <div className="mb-4">
-                  <div className="w-48 h-48 mx-auto bg-gray-200 rounded-full overflow-hidden">
-                    <img 
-                      src={member.photo} 
-                      alt={member.name}
-                      className="w-full h-full object-cover"
-                    />
-                  </div>
-                </div>
-                
-                {/* 名前とプラスボタン */}
-                <div className="flex items-center justify-center gap-2 mb-4">
-                  <h3 className="text-lg font-semibold">{member.name}</h3>
-                  <button
-                    onClick={() => toggleMember(member.id)}
-                    className="w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center hover:bg-blue-700 transition-colors"
-                    aria-label={`${member.name}の詳細を${expandedMember === member.id ? '閉じる' : '開く'}`}
-                  >
-                    <svg 
-                      className={`w-4 h-4 transition-transform ${expandedMember === member.id ? 'rotate-45' : ''}`} 
-                      fill="none" 
-                      stroke="currentColor" 
-                      viewBox="0 0 24 24"
+              <div key={member.id} className="group">
+                <div className="bg-gray-50 rounded-lg p-6 hover:shadow-lg transition-shadow">
+                  {/* メンバー写真 - 正方形 */}
+                  <div className="mb-4 relative">
+                    <div className="w-full aspect-square bg-gray-200 rounded-lg overflow-hidden">
+                      <img 
+                        src={member.photo} 
+                        alt={member.name}
+                        className="w-full h-full object-cover"
+                      />
+                    </div>
+                    
+                    {/* プラスボタン - 写真の右下に配置 */}
+                    <button
+                      onClick={() => toggleMember(member.id)}
+                      className="absolute bottom-2 right-2 w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center hover:bg-blue-700 transition-all shadow-lg"
+                      aria-label={`${member.name}の詳細を${expandedMember === member.id ? '閉じる' : '開く'}`}
                     >
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                    </svg>
-                  </button>
-                </div>
-                
-                {/* 自己紹介（展開時） */}
-                <div className={`overflow-hidden transition-all duration-300 ${
-                  expandedMember === member.id ? 'max-h-40' : 'max-h-0'
-                }`}>
-                  <p className="text-gray-600 text-sm px-4">
-                    {member.introduction}
-                  </p>
+                      <svg 
+                        className={`w-5 h-5 transition-transform duration-300 ${expandedMember === member.id ? 'rotate-45' : ''}`} 
+                        fill="none" 
+                        stroke="currentColor" 
+                        viewBox="0 0 24 24"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                      </svg>
+                    </button>
+                  </div>
+                  
+                  {/* 名前 */}
+                  <h3 className="text-xl font-semibold text-gray-900 text-center mb-3">{member.name}</h3>
+                  
+                  {/* 自己紹介（展開時） */}
+                  <div className={`overflow-hidden transition-all duration-500 ${
+                    expandedMember === member.id ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+                  }`}>
+                    <div className="pt-4 border-t border-gray-200">
+                      <p className="text-gray-600 text-sm leading-relaxed">
+                        {member.introduction}
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </div>
             ))}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -152,8 +152,8 @@ export default function About() {
           <h2 className="text-3xl font-bold text-gray-900 text-center mb-12">メンバー紹介</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12">
             {members.map((member) => (
-              <div key={member.id} className="group h-full">
-                <div className="bg-gray-50 rounded-lg p-6 hover:shadow-lg transition-shadow h-full flex flex-col">
+              <div key={member.id} className="group">
+                <div className="bg-gray-50 rounded-lg p-6 hover:shadow-lg transition-shadow">
                   {/* メンバー写真 - 正方形 */}
                   <div className="mb-4 relative">
                     <div className="w-full aspect-square bg-gray-200 rounded-lg overflow-hidden">
@@ -167,7 +167,7 @@ export default function About() {
                     {/* プラスボタン - 写真の右下に配置 */}
                     <button
                       onClick={() => toggleMember(member.id)}
-                      className="absolute bottom-2 right-2 w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center hover:bg-blue-700 transition-all shadow-lg z-10"
+                      className="absolute bottom-2 right-2 w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center hover:bg-blue-700 transition-all shadow-lg"
                       aria-label={`${member.name}の詳細を${expandedMember === member.id ? '閉じる' : '開く'}`}
                     >
                       <svg 
@@ -184,16 +184,14 @@ export default function About() {
                   {/* 名前 */}
                   <h3 className="text-xl font-semibold text-gray-900 text-center mb-3">{member.name}</h3>
                   
-                  {/* 自己紹介コンテナ - 常に存在 */}
-                  <div className="flex-1">
-                    <div className={`transition-all duration-500 ${
-                      expandedMember === member.id ? 'opacity-100' : 'opacity-0 invisible'
-                    }`}>
-                      <div className="border-t border-gray-200 pt-4">
-                        <p className="text-gray-600 text-sm leading-relaxed">
-                          {member.introduction}
-                        </p>
-                      </div>
+                  {/* 自己紹介（展開時） */}
+                  <div className={`overflow-hidden transition-all duration-500 ${
+                    expandedMember === member.id ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+                  }`}>
+                    <div className="pt-4 border-t border-gray-200">
+                      <p className="text-gray-600 text-sm leading-relaxed">
+                        {member.introduction}
+                      </p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
- 事務所概要ページに6名のメンバー紹介セクションを実装
- 1段3列のレスポンシブレイアウト
- 名前横の＋ボタンで自己紹介の表示/非表示を切り替え
- スムーズなアニメーション効果を実装

🤖 Generated with [Claude Code](https://claude.ai/code)