### PR TITLE
Sanity CMSとサービス関連機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@portabletext/react": "^3.1.0",
     "@sanity/client": "^7.6.0",
     "@sanity/vision": "^3.97.1",
     "next": "15.3.5",

--- a/sanity/package-lock.json
+++ b/sanity/package-lock.json
@@ -8,10 +8,10 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/vision": "^3.97.1",
+        "@sanity/vision": "^3.99.0",
         "react": "^19.1",
         "react-dom": "^19.1",
-        "sanity": "^3.97.1",
+        "sanity": "^3.99.0",
         "styled-components": "^6.1.18"
       },
       "devDependencies": {
@@ -1535,9 +1535,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.0.tgz",
-      "integrity": "sha512-LOAozRVbqxEVjSKfhGnuLoE4Kz4Oc5UJzuvFUhSsQzdCdaAQu06mG8zDv2GFSerM62nImUZ7K92vxnQcLSDlCQ==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+      "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1936,9 +1936,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-      "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2267,9 +2267,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
+      "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
       "cpu": [
         "ppc64"
       ],
@@ -2283,9 +2283,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
+      "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
       "cpu": [
         "arm"
       ],
@@ -2299,9 +2299,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
+      "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
       "cpu": [
         "arm64"
       ],
@@ -2315,9 +2315,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
+      "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
       "cpu": [
         "x64"
       ],
@@ -2331,9 +2331,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
+      "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
       "cpu": [
         "arm64"
       ],
@@ -2347,9 +2347,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
+      "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
       "cpu": [
         "x64"
       ],
@@ -2363,9 +2363,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
       "cpu": [
         "arm64"
       ],
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
+      "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
       "cpu": [
         "x64"
       ],
@@ -2395,9 +2395,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
+      "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
       "cpu": [
         "arm"
       ],
@@ -2411,9 +2411,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
+      "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
       "cpu": [
         "arm64"
       ],
@@ -2427,9 +2427,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
+      "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
       "cpu": [
         "ia32"
       ],
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
+      "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
       "cpu": [
         "loong64"
       ],
@@ -2459,9 +2459,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
+      "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
       "cpu": [
         "mips64el"
       ],
@@ -2475,9 +2475,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
+      "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
       "cpu": [
         "ppc64"
       ],
@@ -2491,9 +2491,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
+      "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
       "cpu": [
         "riscv64"
       ],
@@ -2507,9 +2507,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
+      "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
       "cpu": [
         "s390x"
       ],
@@ -2523,9 +2523,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
+      "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
       "cpu": [
         "x64"
       ],
@@ -2539,9 +2539,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
       "cpu": [
         "arm64"
       ],
@@ -2555,9 +2555,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
       "cpu": [
         "x64"
       ],
@@ -2571,9 +2571,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
       "cpu": [
         "arm64"
       ],
@@ -2587,9 +2587,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
       "cpu": [
         "x64"
       ],
@@ -2602,10 +2602,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
+      "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
+      "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
       "cpu": [
         "x64"
       ],
@@ -2619,9 +2635,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
+      "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
       "cpu": [
         "arm64"
       ],
@@ -2635,9 +2651,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
+      "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
       "cpu": [
         "ia32"
       ],
@@ -2651,9 +2667,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
+      "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
       "cpu": [
         "x64"
       ],
@@ -2734,9 +2750,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2771,9 +2787,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
-      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2802,19 +2818,6 @@
       "dependencies": {
         "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3462,6 +3465,74 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@mux/mux-data-google-ima": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
+      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
+      "license": "MIT",
+      "dependencies": {
+        "mux-embed": "5.9.0"
+      }
+    },
+    "node_modules/@mux/mux-player": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.5.1.tgz",
+      "integrity": "sha512-PSi3mPb4LrEh4i3xUdodaEvMrbbpKbL2yaewRjsqBr3PFb+hd/Dp1KtyaAnXaBCHl09hDURUSrqYpg1cZvwDiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.26.1",
+        "@mux/playback-core": "0.30.1",
+        "media-chrome": "~4.11.1",
+        "player.style": "^0.1.9"
+      }
+    },
+    "node_modules/@mux/mux-player-react": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.5.1.tgz",
+      "integrity": "sha512-tm32fSo9IBA/J8AD99bp64CyBkmv8jtsn4RhSHgNufvfWJUMBFJ7cfXgLsxiG/VdegpfBLRatMC5YiuZjoZ6yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player": "3.5.1",
+        "@mux/playback-core": "0.30.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mux/mux-video": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.26.1.tgz",
+      "integrity": "sha512-gkMdBAgNlB4+krANZHkQFzYWjWeNsJz69y1/hnPtmNQnpvW+O7oc71OffcZrbblyibSxWMQ6MQpYmBVjXlp6sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-data-google-ima": "0.2.8",
+        "@mux/playback-core": "0.30.1",
+        "castable-video": "~1.1.10",
+        "custom-media-element": "~1.4.5",
+        "media-tracks": "~0.3.3"
+      }
+    },
+    "node_modules/@mux/playback-core": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.30.1.tgz",
+      "integrity": "sha512-rnO1NE9xHDyzbAkmE6ygJYcD7cyyMt7xXqWTykxlceaoSXLjUqgp42HDio7Lcidto4x/O4FIa7ztjV2aCBCXgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hls.js": "~1.6.6",
+        "mux-embed": "^5.8.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3498,9 +3569,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.4.1.tgz",
-      "integrity": "sha512-RYonV4IJZcGAoi3pdo5CPl5hVH1YdtQMEX77TLdgTPVrMmIjbiB0Borfguj/mdDF2TjLXp+Z+RbmLUejuhSYTA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UYWyDFNKFyzgXVXO0DHfOvJ/8qpw4yPYe7fOHausDEVU44qjDr90ZnfYTljZPK8dhgMggxiZs9n+TFajnXRp7g==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -3599,9 +3670,9 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
-      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
@@ -3862,26 +3933,27 @@
       }
     },
     "node_modules/@portabletext/block-tools": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-1.1.34.tgz",
-      "integrity": "sha512-Km4ZbDafiOdREy+QxsEXIqVFuL+tPXqETUjlr7BJ7sYfoEeSflyeSx0A13X335QauOQTaajKdqQxwbfV1VjqUg==",
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-1.1.38.tgz",
+      "integrity": "sha512-Mm+8GrE0iwfUCqF5lJ8Xbt0BIRo7qdbILtK4mldKiHjliG7gX78u/qimAFPlKuozZO0Vu21beDVnEI+tZ4zbXw==",
       "license": "MIT",
       "dependencies": {
         "get-random-values-esm": "1.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "@sanity/types": "^3.96.0",
+        "@sanity/types": "^3.98.0 || ^4.0.0-0",
         "@types/react": "18 || 19"
       }
     },
     "node_modules/@portabletext/editor": {
-      "version": "1.55.16",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-1.55.16.tgz",
-      "integrity": "sha512-ADpgcuhjfdZLF/5Ez+MLF7Tjoi9FLUB7qREO8WkTa+4TkeyElK6A72dui3/HZjH38FJDQrx7NlGPwQ7Hz0cj2A==",
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-1.58.0.tgz",
+      "integrity": "sha512-qlqx0VPr6VMAZR8w3v4YJTbds/g6QannBKwcuITpfv19rL0DqP/zxFS/2dtygv7kpjyWsrhgzq1zveY4qTDrVw==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/block-tools": "1.1.34",
+        "@portabletext/block-tools": "1.1.38",
+        "@portabletext/keyboard-shortcuts": "1.1.0",
         "@portabletext/patches": "1.1.5",
         "@portabletext/to-html": "^2.0.14",
         "@xstate/react": "^6.0.0",
@@ -3895,14 +3967,14 @@
         "slate-dom": "^0.116.0",
         "slate-react": "0.117.3",
         "use-effect-event": "^1.0.2",
-        "xstate": "^5.20.0"
+        "xstate": "^5.20.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/schema": "^3.96.0",
-        "@sanity/types": "^3.96.0",
+        "@sanity/schema": "^3.98.0 || ^4.0.0-0",
+        "@sanity/types": "^3.98.0 || ^4.0.0-0",
         "react": "^16.9 || ^17 || ^18 || ^19",
         "rxjs": "^7.8.2"
       }
@@ -3915,6 +3987,12 @@
       "peerDependencies": {
         "react": "^18.3 || ^19.0.0-0"
       }
+    },
+    "node_modules/@portabletext/keyboard-shortcuts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/keyboard-shortcuts/-/keyboard-shortcuts-1.1.0.tgz",
+      "integrity": "sha512-krhhFXLdoSNRxPZVygdyKqNNXRGbjLjkmP7HKM/pweDlgjpIAaw9vsOtTkEdS+eFuWYQ/suj4Py2aOyAwrjKpA==",
+      "license": "MIT"
     },
     "node_modules/@portabletext/patches": {
       "version": "1.1.5",
@@ -4006,9 +4084,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.2.tgz",
-      "integrity": "sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.0.tgz",
+      "integrity": "sha512-2o/FgACbji4tW1dzXOqAV15Eu7DdgbKsF2QKcxfG4xbh5iwU7yr5RRP5/U+0asQliSYv5M4o7BevlGIoSL0LXg==",
       "cpu": [
         "arm"
       ],
@@ -4019,9 +4097,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.2.tgz",
-      "integrity": "sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.0.tgz",
+      "integrity": "sha512-PSZ0SvMOjEAxwZeTx32eI/j5xSYtDCRxGu5k9zvzoY77xUNssZM+WV6HYBLROpY5CkXsbQjvz40fBb7WPwDqtQ==",
       "cpu": [
         "arm64"
       ],
@@ -4032,9 +4110,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.2.tgz",
-      "integrity": "sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.0.tgz",
+      "integrity": "sha512-BA4yPIPssPB2aRAWzmqzQ3y2/KotkLyZukVB7j3psK/U3nVJdceo6qr9pLM2xN6iRP/wKfxEbOb1yrlZH6sYZg==",
       "cpu": [
         "arm64"
       ],
@@ -4045,9 +4123,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.2.tgz",
-      "integrity": "sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.0.tgz",
+      "integrity": "sha512-Pr2o0lvTwsiG4HCr43Zy9xXrHspyMvsvEw4FwKYqhli4FuLE5FjcZzuQ4cfPe0iUFCvSQG6lACI0xj74FDZKRA==",
       "cpu": [
         "x64"
       ],
@@ -4058,9 +4136,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.2.tgz",
-      "integrity": "sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.0.tgz",
+      "integrity": "sha512-lYE8LkE5h4a/+6VnnLiL14zWMPnx6wNbDG23GcYFpRW1V9hYWHAw9lBZ6ZUIrOaoK7NliF1sdwYGiVmziUF4vA==",
       "cpu": [
         "arm64"
       ],
@@ -4071,9 +4149,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.2.tgz",
-      "integrity": "sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.0.tgz",
+      "integrity": "sha512-PVQWZK9sbzpvqC9Q0GlehNNSVHR+4m7+wET+7FgSnKG3ci5nAMgGmr9mGBXzAuE5SvguCKJ6mHL6vq1JaJ/gvw==",
       "cpu": [
         "x64"
       ],
@@ -4084,9 +4162,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.2.tgz",
-      "integrity": "sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.0.tgz",
+      "integrity": "sha512-hLrmRl53prCcD+YXTfNvXd776HTxNh8wPAMllusQ+amcQmtgo3V5i/nkhPN6FakW+QVLoUUr2AsbtIRPFU3xIA==",
       "cpu": [
         "arm"
       ],
@@ -4097,9 +4175,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.2.tgz",
-      "integrity": "sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.0.tgz",
+      "integrity": "sha512-XBKGSYcrkdiRRjl+8XvrUR3AosXU0NvF7VuqMsm7s5nRy+nt58ZMB19Jdp1RdqewLcaYnpk8zeVs/4MlLZEJxw==",
       "cpu": [
         "arm"
       ],
@@ -4110,9 +4188,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.2.tgz",
-      "integrity": "sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.0.tgz",
+      "integrity": "sha512-fRvZZPUiBz7NztBE/2QnCS5AtqLVhXmUOPj9IHlfGEXkapgImf4W9+FSkL8cWqoAjozyUzqFmSc4zh2ooaeF6g==",
       "cpu": [
         "arm64"
       ],
@@ -4123,9 +4201,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.2.tgz",
-      "integrity": "sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.0.tgz",
+      "integrity": "sha512-Btv2WRZOcUGi8XU80XwIvzTg4U6+l6D0V6sZTrZx214nrwxw5nAi8hysaXj/mctyClWgesyuxbeLylCBNauimg==",
       "cpu": [
         "arm64"
       ],
@@ -4136,9 +4214,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.2.tgz",
-      "integrity": "sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.0.tgz",
+      "integrity": "sha512-Li0emNnwtUZdLwHjQPBxn4VWztcrw/h7mgLyHiEI5Z0MhpeFGlzaiBHpSNVOMB/xucjXTTcO+dhv469Djr16KA==",
       "cpu": [
         "loong64"
       ],
@@ -4149,9 +4227,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.2.tgz",
-      "integrity": "sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.0.tgz",
+      "integrity": "sha512-sB8+pfkYx2kvpDCfd63d5ScYT0Fz1LO6jIb2zLZvmK9ob2D8DeVqrmBDE0iDK8KlBVmsTNzrjr3G1xV4eUZhSw==",
       "cpu": [
         "ppc64"
       ],
@@ -4162,9 +4240,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.2.tgz",
-      "integrity": "sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.0.tgz",
+      "integrity": "sha512-5GQ6PFhh7E6jQm70p1aW05G2cap5zMOvO0se5JMecHeAdj5ZhWEHbJ4hiKpfi1nnnEdTauDXxPgXae/mqjow9w==",
       "cpu": [
         "riscv64"
       ],
@@ -4175,9 +4253,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.2.tgz",
-      "integrity": "sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.0.tgz",
+      "integrity": "sha512-N/euLsBd1rekWcuduakTo/dJw6U6sBP3eUq+RXM9RNfPuWTvG2w/WObDkIvJ2KChy6oxZmOSC08Ak2OJA0UiAA==",
       "cpu": [
         "riscv64"
       ],
@@ -4188,9 +4266,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.2.tgz",
-      "integrity": "sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.0.tgz",
+      "integrity": "sha512-2l9sA7d7QdikL0xQwNMO3xURBUNEWyHVHfAsHsUdq+E/pgLTUcCE+gih5PCdmyHmfTDeXUWVhqL0WZzg0nua3g==",
       "cpu": [
         "s390x"
       ],
@@ -4201,9 +4279,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.2.tgz",
-      "integrity": "sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.0.tgz",
+      "integrity": "sha512-XZdD3fEEQcwG2KrJDdEQu7NrHonPxxaV0/w2HpvINBdcqebz1aL+0vM2WFJq4DeiAVT6F5SUQas65HY5JDqoPw==",
       "cpu": [
         "x64"
       ],
@@ -4214,9 +4292,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.2.tgz",
-      "integrity": "sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.0.tgz",
+      "integrity": "sha512-7ayfgvtmmWgKWBkCGg5+xTQ0r5V1owVm67zTrsEY1008L5ro7mCyGYORomARt/OquB9KY7LpxVBZes+oSniAAQ==",
       "cpu": [
         "x64"
       ],
@@ -4227,9 +4305,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.2.tgz",
-      "integrity": "sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.0.tgz",
+      "integrity": "sha512-B+IJgcBnE2bm93jEW5kHisqvPITs4ddLOROAcOc/diBgrEiQJJ6Qcjby75rFSmH5eMGrqJryUgJDhrfj942apQ==",
       "cpu": [
         "arm64"
       ],
@@ -4240,9 +4318,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.2.tgz",
-      "integrity": "sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.0.tgz",
+      "integrity": "sha512-+CXwwG66g0/FpWOnP/v1HnrGVSOygK/osUbu3wPRy8ECXjoYKjRAyfxYpDQOfghC5qPJYLPH0oN4MCOjwgdMug==",
       "cpu": [
         "ia32"
       ],
@@ -4253,9 +4331,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.2.tgz",
-      "integrity": "sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.0.tgz",
+      "integrity": "sha512-SRf1cytG7wqcHVLrBc9VtPK4pU5wxiB/lNIkNmW2ApKXIg+RpqwHfsaEK+e7eH4A1BpI6BX/aBWXxZCIrJg3uA==",
       "cpu": [
         "x64"
       ],
@@ -4285,22 +4363,22 @@
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.97.1.tgz",
-      "integrity": "sha512-vLH2UcWlXbw8+PDAEneR67VjrTZbi+tWz3SecGvwWIcOLOLVswzUbihoFbLCbnluzNENPtsXXdZqtG1FGolKqw==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.99.0.tgz",
+      "integrity": "sha512-4Davi8d5WCs6vK7095KW/8B1Y8VjEwIdCQR7M+MuiUiBGO1oI3unpVP4SsDsQSw51j3qt54AchM0K0Po8DzTdg==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.4",
         "@sanity/client": "^7.6.0",
-        "@sanity/codegen": "3.97.1",
-        "@sanity/runtime-cli": "^9.1.2",
+        "@sanity/codegen": "3.99.0",
+        "@sanity/runtime-cli": "^9.2.0",
         "@sanity/telemetry": "^0.8.0",
         "@sanity/template-validator": "^2.4.3",
-        "@sanity/util": "3.97.1",
+        "@sanity/util": "3.99.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "decompress": "^4.2.0",
-        "esbuild": "0.25.5",
+        "esbuild": "0.25.6",
         "esbuild-register": "^3.6.0",
         "get-it": "^8.6.10",
         "groq-js": "^1.17.1",
@@ -4344,9 +4422,9 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.97.1.tgz",
-      "integrity": "sha512-B0IpL/JY3Dwr3C1UwDjvY7Jcg/AHArlQ8YhYXrtoXKokic15b8q2c+YnNbKBEc7qqWQMeIRJx3tTfUiK3s6M/A==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.99.0.tgz",
+      "integrity": "sha512-XTI6X6uFCms7PLHtCXNTLIoAbR5Mjg5yPrEn3EhHlGyNJV6CSyEOUtd+KyjrAQzC0FQPvT5aZJF1x5hVX+Cwdw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -4359,7 +4437,7 @@
         "@babel/types": "^7.28.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
-        "groq": "3.97.1",
+        "groq": "3.99.0",
         "groq-js": "^1.17.1",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
@@ -4379,14 +4457,14 @@
       }
     },
     "node_modules/@sanity/comlink": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@sanity/comlink/-/comlink-3.0.5.tgz",
-      "integrity": "sha512-aYdqV8pJ6UT/3WucER5PBMGIlAt26wKiVYcmFSA7k3dmcEaPOd8tib93bwHfQsVXzGGnUaf0e8IacKYoyTwzCw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@sanity/comlink/-/comlink-3.0.7.tgz",
+      "integrity": "sha512-hN2jwNyVrXqHyrKWLxe6Po9YqMbX8NrrOIC3qkXvWM1gYkztvYAVQHjmcPuFU0sluneazxxK+/NQJNkwdz/Dcw==",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",
         "uuid": "^11.1.0",
-        "xstate": "^5.19.2"
+        "xstate": "^5.20.1"
       },
       "engines": {
         "node": ">=18"
@@ -4406,9 +4484,9 @@
       }
     },
     "node_modules/@sanity/descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/descriptors/-/descriptors-1.0.0.tgz",
-      "integrity": "sha512-Gxp/N1GHkteSALUkURxMXZdKxl8LzUqfYMk0vq37Z4YznMs7wMDNHIgD5SwL3E3w6rQkALz69xki8hUBa23GsA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@sanity/descriptors/-/descriptors-1.1.1.tgz",
+      "integrity": "sha512-pTqpyLhH3z4NDhjKHyfL+quVN0ixA8NikcdqxRmL2iqPZuJavi81eKm631PaUqJGbY1kh1+vHnO1/GgWIcjgxw==",
       "license": "MIT",
       "dependencies": {
         "sha256-uint8array": "^0.10.7"
@@ -4418,9 +4496,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.97.1.tgz",
-      "integrity": "sha512-g227geLYNxBbe8wC/zuRSxdnzdHyEz5DgnPRpm0ANcG/s5Rp9fw05hnEAUHq35V/F6QA6Vnig6pPrXd6SU7TMg==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.99.0.tgz",
+      "integrity": "sha512-iBPPSYAv/frAY73THZOLxVCZ82s91LY/X/8/TjdtMNAON0AUjRWDfZB5wN+JieMMmgwE7WBAUi1wVjPe9ie9qQ==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0"
@@ -4686,18 +4764,18 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.38.2",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.38.2.tgz",
-      "integrity": "sha512-7KUEiksAjr+Ub+xbWbIIrNlfEesmqJcBW+n7zOr65TN8lS9WarTzIClDjbeZ13yYMS9e9FOKIzXVJC8UFwIseA==",
+      "version": "3.38.3",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.38.3.tgz",
+      "integrity": "sha512-tWEcM5+RN+VDFuouWy6Imqmveko8tzksNYPyeMkqlkF8+s2OI2rGtMQVWvStu6zk4jVQoWXnG9hnt7TAUqKeTQ==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/asset-utils": "^2.0.6",
+        "@sanity/asset-utils": "^2.2.1",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "^3.59.1",
+        "@sanity/mutator": "^3.98.0",
         "@sanity/uuid": "^3.0.2",
-        "debug": "^4.3.4",
+        "debug": "^4.4.1",
         "file-url": "^2.0.2",
-        "get-it": "^8.4.21",
+        "get-it": "^8.6.10",
         "get-uri": "^2.0.2",
         "gunzip-maybe": "^1.4.1",
         "is-tar": "^1.0.0",
@@ -4710,7 +4788,7 @@
         "pretty-ms": "^7.0.1",
         "rimraf": "^6.0.1",
         "split2": "^4.2.0",
-        "tar-fs": "^2.1.2",
+        "tar-fs": "^2.1.3",
         "tinyglobby": "^0.2.9"
       },
       "bin": {
@@ -4879,15 +4957,15 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.97.1.tgz",
-      "integrity": "sha512-s/TcLJlSuensS4GDv3bD1MVrZUvDfQ3NsueQlFpLqEzs36r6vg7J4T92Jfiw4oRn7pbWWwrof66IRrcvD6oUYA==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.99.0.tgz",
+      "integrity": "sha512-tTPwwnmS2QYTsC5ZmMvXTY7IUUVsEpSVZVL2zKx1KDbSbEz/a2MN+sqney9S5h4xHZIZ11Ju1T9N27OgkA7Ipw==",
       "license": "MIT",
       "dependencies": {
         "@sanity/client": "^7.6.0",
         "@sanity/mutate": "^0.12.4",
-        "@sanity/types": "3.97.1",
-        "@sanity/util": "3.97.1",
+        "@sanity/types": "3.99.0",
+        "@sanity/util": "3.99.0",
         "arrify": "^2.0.1",
         "debug": "^4.3.4",
         "fast-fifo": "^1.3.2",
@@ -4950,38 +5028,38 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.97.1.tgz",
-      "integrity": "sha512-02urNYncvvv0eYyc3rH0xrvWpNsfT86zAVuyt9e1pRaG3tw69oGBf8JJjlwaBp+YshiNlD+e9G8kKjxwm9Ur0A==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.99.0.tgz",
+      "integrity": "sha512-CrX2B2OXYtjFpLQeUC971XiMeyOXyDaMK5qH150qYkg6sVuIdsPjN0kXyMhWR6LuTp96blUOUNPQhkTsfAo44w==",
       "license": "MIT",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.2.0",
-        "@sanity/types": "3.97.1",
+        "@sanity/types": "3.99.0",
         "@sanity/uuid": "^3.0.2",
         "debug": "^4.3.4",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/presentation-comlink": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.21.tgz",
-      "integrity": "sha512-23jXRySgkop9ISHvxkFVwsib8kbS1VTbKf7yfhrJWLGHcCzQ6MJTs9Sh4oWMEqIhhcHsv23Lvm+O4rr53arEuA==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation-comlink/-/presentation-comlink-1.0.23.tgz",
+      "integrity": "sha512-ISSLfHa4SXr4vddCrdXa7pCFJFpJoIz5gKEtIYNi1FfKhNrY7nty4UWDxDBCOYOjXfXnaK8rgh0HOu/WWCYeIg==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/comlink": "^3.0.5",
-        "@sanity/visual-editing-types": "^1.1.0"
+        "@sanity/comlink": "^3.0.7",
+        "@sanity/visual-editing-types": "^1.1.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^7.1.0"
+        "@sanity/client": "^7.6.0"
       }
     },
     "node_modules/@sanity/preview-url-secret": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-2.1.11.tgz",
-      "integrity": "sha512-kMxOvXARbDZ8g8vWPjCBJ+QYaPXoOYXlsHfh727mzl/Ibmvlh9F9fLuyAwxSvq4J2VWXZegb8kmKlEakgld0dg==",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-2.1.12.tgz",
+      "integrity": "sha512-RJj9hueVE4lEYdvOokFvoCCdgkIcH1pkjsugXi2sp/y4MFLT+tX7o02E/cLGSfeTF6tTbJmaNdbE8WqvBwyh9w==",
       "license": "MIT",
       "dependencies": {
         "@sanity/uuid": "3.0.2"
@@ -4990,19 +5068,20 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^7.1.0"
+        "@sanity/client": "^7.6.0"
       }
     },
     "node_modules/@sanity/runtime-cli": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-9.1.2.tgz",
-      "integrity": "sha512-TOsWsCXaPqlnJj/XPJkJvdQHfuey2LJLZSTqz0wR3BvCNEppyKNalNGoUUNysyUAQnq0WsYOXhx7timXvp7Zzw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@sanity/runtime-cli/-/runtime-cli-9.2.0.tgz",
+      "integrity": "sha512-7EJOkiOuw3HWw/JyN4jpCOXPURquLIaisjcppReTTqp/w9cw/Cbqdw+8bgQDMzZg8uphi9vOzJk5C4jx7Zg2RA==",
       "license": "MIT",
       "dependencies": {
         "@architect/hydrate": "^4.0.8",
         "@architect/inventory": "^4.0.9",
         "@oclif/core": "^4.3.0",
         "@oclif/plugin-help": "^6.2.28",
+        "@sanity/client": "^7.3.0",
         "adm-zip": "^0.5.16",
         "array-treeify": "^0.1.5",
         "cardinal": "^2.1.1",
@@ -5291,14 +5370,14 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.97.1.tgz",
-      "integrity": "sha512-bGIHtSBtdlBcNbSJ0TeLwZq/Pi5bk1uHdq50rmyQgeYHD2GC3nmcCerlm/1eoPjSWYuXduLPfmCYgLU5rFZIxQ==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.99.0.tgz",
+      "integrity": "sha512-L0b0Tl3RfoVZM5gYdG8WSLOjlGcJ/xWALz5dkx2bPgnCDVYt3YZDrVO/mzRiSor0cO8i4iU35CKS3tBuXbeZTA==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/descriptors": "1.0.0",
+        "@sanity/descriptors": "^1.1.1",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.97.1",
+        "@sanity/types": "3.99.0",
         "arrify": "^2.0.1",
         "groq-js": "^1.17.1",
         "humanize-list": "^1.0.1",
@@ -5378,9 +5457,9 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.97.1.tgz",
-      "integrity": "sha512-ibOauea3H1DYZKqpL56HM92u+upd1bn+KKH+AxZGdypGWaYlUPDyU8moByO+A3rJTEaD554jRdqDCfqySYCFkg==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.99.0.tgz",
+      "integrity": "sha512-a766U9VSoyOSWq+RZz9wsEo/Nnn+inDkEcdGu+rHFuygdepullB/RZpF2MxNsfUMCSPnajgG1Tm9lhwbSmlySA==",
       "license": "MIT",
       "dependencies": {
         "@sanity/client": "^7.6.0",
@@ -5391,20 +5470,20 @@
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.16.2.tgz",
-      "integrity": "sha512-r4kiPsaW56l2kboCAY9GX3e4PrUaIe7SW/ICSrlnf5Gw9krLMIx8GNNvb0NsCg7mLSCDF1upeIEQRz01JniqYg==",
+      "version": "2.16.7",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.16.7.tgz",
+      "integrity": "sha512-gRTX/QyUR2Bg8mu7rZBWxt+eE1EFsnGgiqv9OZhQ5Yvy2tZ00W6TNLfCVdBBTDRScIWL2ytnGR7X8Tcb3Ie+gA==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.3",
+        "@floating-ui/react-dom": "^2.1.4",
         "@juggle/resize-observer": "^3.4.0",
         "@sanity/color": "^3.0.6",
-        "@sanity/icons": "^3.7.0",
+        "@sanity/icons": "^3.7.4",
         "csstype": "^3.1.3",
-        "framer-motion": "^12.9.7",
+        "framer-motion": "^12.23.3",
         "react-compiler-runtime": "19.1.0-rc.2",
         "react-refractor": "^2.2.0",
-        "use-effect-event": "^2.0.1"
+        "use-effect-event": "^2.0.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5417,15 +5496,15 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.97.1.tgz",
-      "integrity": "sha512-SPZlP6fOXtPD5mT6O++M1q940wo6n6nQL9HHWizzkgMldJZoI1SLC/R+ge4RsbxN5vIil3yDnGRhKoohEXafEQ==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.99.0.tgz",
+      "integrity": "sha512-+yuMi2nTZfyohlS4tFryYMTG9gkjw7aToMM3A3TrtfbQPGi+9ZVBPNeer2r/uaJFChPaxEC9hZV0gXZQpPiJ0w==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.2.0",
         "@date-fns/utc": "^2.1.0",
         "@sanity/client": "^7.6.0",
-        "@sanity/types": "3.97.1",
+        "@sanity/types": "3.99.0",
         "date-fns": "^4.1.0",
         "get-random-values-esm": "1.0.2",
         "rxjs": "^7.8.2"
@@ -5455,9 +5534,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.97.1.tgz",
-      "integrity": "sha512-xF7zyXenQsce68k/t+a2AwBQ5Gzkyjd53ar3Ij2e9XXCxsljJeCkBRVSQNGXqfCiNktqvdDLabzF4yME5Y2WBA==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.99.0.tgz",
+      "integrity": "sha512-vkCbUSEOrXvs/k3wmrt/vOvhu+ZXeBcxQq/w0pNKefBVCkPUVTwPfIn4qir7O78lCr6qitcKpdR+/LbQZwDvvw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.6",
@@ -5473,7 +5552,7 @@
         "@rexxars/react-split-pane": "^1.0.0",
         "@sanity/color": "^3.0.6",
         "@sanity/icons": "^3.7.4",
-        "@sanity/ui": "^2.16.2",
+        "@sanity/ui": "^2.16.4",
         "@sanity/uuid": "^3.0.2",
         "@uiw/react-codemirror": "^4.23.8",
         "is-hotkey-esm": "^1.0.0",
@@ -5493,15 +5572,15 @@
       }
     },
     "node_modules/@sanity/visual-editing-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.0.tgz",
-      "integrity": "sha512-Tb4bdy+He/ZFoCMbfPMiSq7rQHfShMOSKg6SC8zbJug9EKjfOzuWEJ5AS4YVu+8vgaPs0KKibyCoOuHTV95n0w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@sanity/visual-editing-types/-/visual-editing-types-1.1.1.tgz",
+      "integrity": "sha512-rXjFPqLWKbC9K4d1C8ip12RudY4P7wGg0uQGOZhwf44SJDpYJkAXjsS1EwdqQhCxAL3mdyxB7rkCZYGZlj/E1A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^7.1.0",
+        "@sanity/client": "^7.6.0",
         "@sanity/types": "*"
       },
       "peerDependenciesMeta": {
@@ -5768,9 +5847,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
+      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -5859,17 +5938,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz",
-      "integrity": "sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.36.0.tgz",
+      "integrity": "sha512-lZNihHUVB6ZZiPBNgOQGSxUASI7UJWhT8nHyUGCnaQ28XFCw98IfrMCG3rUl1uwUWoAvodJQby2KTs79UTcrAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/type-utils": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/type-utils": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -5883,7 +5962,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.35.1",
+        "@typescript-eslint/parser": "^8.36.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
@@ -5899,16 +5978,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
-      "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.36.0.tgz",
+      "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/typescript-estree": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5924,14 +6003,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
-      "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.36.0.tgz",
+      "integrity": "sha512-JAhQFIABkWccQYeLMrHadu/fhpzmSQ1F1KXkpzqiVxA/iYI6UnRt2trqXHt1sYEcw1mxLnB9rKMsOxXPxowN/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.35.1",
-        "@typescript-eslint/types": "^8.35.1",
+        "@typescript-eslint/tsconfig-utils": "^8.36.0",
+        "@typescript-eslint/types": "^8.36.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5946,14 +6025,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
-      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.36.0.tgz",
+      "integrity": "sha512-wCnapIKnDkN62fYtTGv2+RY8FlnBYA3tNm0fm91kc2BjPhV2vIjwwozJ7LToaLAyb1ca8BxrS7vT+Pvvf7RvqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1"
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5964,9 +6043,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
-      "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.36.0.tgz",
+      "integrity": "sha512-Nhh3TIEgN18mNbdXpd5Q8mSCBnrZQeY9V7Ca3dqYvNDStNIGRmJA6dmrIPMJ0kow3C7gcQbpsG2rPzy1Ks/AnA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5981,14 +6060,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
-      "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.36.0.tgz",
+      "integrity": "sha512-5aaGYG8cVDd6cxfk/ynpYzxBRZJk7w/ymto6uiyUFtdCozQIsQWh7M28/6r57Fwkbweng8qAzoMCPwSJfWlmsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -6005,9 +6084,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
-      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.36.0.tgz",
+      "integrity": "sha512-xGms6l5cTJKQPZOKM75Dl9yBfNdGeLRsIyufewnxT4vZTrjC0ImQT4fj8QmtJK84F58uSh5HVBSANwcfiXxABQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6019,16 +6098,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
-      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.36.0.tgz",
+      "integrity": "sha512-JaS8bDVrfVJX4av0jLpe4ye0BpAaUW7+tnS4Y4ETa3q7NoZgzYbN9zDQTJ8kPb5fQ4n0hliAt9tA4Pfs2zA2Hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.35.1",
-        "@typescript-eslint/tsconfig-utils": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/project-service": "8.36.0",
+        "@typescript-eslint/tsconfig-utils": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -6087,16 +6166,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
-      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.36.0.tgz",
+      "integrity": "sha512-VOqmHu42aEMT+P2qYjylw6zP/3E/HvptRwdn/PZxyV27KhZg2IOszXod4NcXisWzPAGSS4trE/g4moNj6XmH2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1"
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/typescript-estree": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6111,13 +6190,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
-      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.36.0.tgz",
+      "integrity": "sha512-vZrhV2lRPWDuGoxcmrzRZyxAggPL+qp3WzUrlZD+slFueDiYHxeBa34dUXPuC0RmGKzl4lS5kFJYvKCq9cnNDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/types": "8.36.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -6180,6 +6259,12 @@
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
+    },
+    "node_modules/@vercel/edge": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.2.tgz",
+      "integrity": "sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.6.0",
@@ -6276,9 +6361,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -6369,18 +6454,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/archiver": {
@@ -6729,9 +6802,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
-      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
+      "integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -7074,6 +7147,24 @@
       },
       "bin": {
         "cdl": "bin/cdl.js"
+      }
+    },
+    "node_modules/castable-video": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.10.tgz",
+      "integrity": "sha512-/T1I0A4VG769wTEZ8gWuy1Crn9saAfRTd1UYTb8xbOPlN78+zOi/1nU2dD5koNkfE5VWvgabkIqrGKmyNXOjSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "~1.4.5"
+      }
+    },
+    "node_modules/ce-la-react": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.0.tgz",
+      "integrity": "sha512-84SEDLNHaAjykzlkqgKRq95hA3qnxrsTrwh4hTgBq6tfpINqajxz4bkz9q4orhUfpqDPQRgdCzYTF3bHcvTIlQ==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": ">=17.0.0"
       }
     },
     "node_modules/chalk": {
@@ -7472,12 +7563,12 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
-      "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.44.0.tgz",
+      "integrity": "sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.25.0"
+        "browserslist": "^4.25.1"
       },
       "funding": {
         "type": "opencollective",
@@ -7628,6 +7719,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/custom-media-element": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.5.tgz",
+      "integrity": "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==",
       "license": "MIT"
     },
     "node_modules/cyclist": {
@@ -8307,9 +8404,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.179",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.179.tgz",
-      "integrity": "sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==",
+      "version": "1.5.182",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz",
+      "integrity": "sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -8522,9 +8619,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
+      "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8534,31 +8631,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
+        "@esbuild/aix-ppc64": "0.25.6",
+        "@esbuild/android-arm": "0.25.6",
+        "@esbuild/android-arm64": "0.25.6",
+        "@esbuild/android-x64": "0.25.6",
+        "@esbuild/darwin-arm64": "0.25.6",
+        "@esbuild/darwin-x64": "0.25.6",
+        "@esbuild/freebsd-arm64": "0.25.6",
+        "@esbuild/freebsd-x64": "0.25.6",
+        "@esbuild/linux-arm": "0.25.6",
+        "@esbuild/linux-arm64": "0.25.6",
+        "@esbuild/linux-ia32": "0.25.6",
+        "@esbuild/linux-loong64": "0.25.6",
+        "@esbuild/linux-mips64el": "0.25.6",
+        "@esbuild/linux-ppc64": "0.25.6",
+        "@esbuild/linux-riscv64": "0.25.6",
+        "@esbuild/linux-s390x": "0.25.6",
+        "@esbuild/linux-x64": "0.25.6",
+        "@esbuild/netbsd-arm64": "0.25.6",
+        "@esbuild/netbsd-x64": "0.25.6",
+        "@esbuild/openbsd-arm64": "0.25.6",
+        "@esbuild/openbsd-x64": "0.25.6",
+        "@esbuild/openharmony-arm64": "0.25.6",
+        "@esbuild/sunos-x64": "0.25.6",
+        "@esbuild/win32-arm64": "0.25.6",
+        "@esbuild/win32-ia32": "0.25.6",
+        "@esbuild/win32-x64": "0.25.6"
       }
     },
     "node_modules/esbuild-register": {
@@ -8595,9 +8693,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
-      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8605,9 +8703,9 @@
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
         "@eslint/config-helpers": "^0.3.0",
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.30.1",
+        "@eslint/js": "9.31.0",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -9008,20 +9106,6 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -9450,13 +9534,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.23.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.0.tgz",
-      "integrity": "sha512-xf6NxTGAyf7zR4r2KlnhFmsRfKIbjqeBupEDBAaEtVIBJX96sAon00kMlsKButSIRwPSHjbRrAPnYdJJ9kyhbA==",
+      "version": "12.23.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.3.tgz",
+      "integrity": "sha512-llmLkf44zuIZOPSrE4bl4J0UTg6bav+rlKEfMRKgvDMXqBrUtMg6cspoQeRVK3nqRLxTmAJhfGXk39UDdZD7Kw==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.22.0",
-        "motion-utils": "^12.19.0",
+        "motion-dom": "^12.23.2",
+        "motion-utils": "^12.23.2",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -9977,9 +10061,9 @@
       "license": "MIT"
     },
     "node_modules/groq": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.97.1.tgz",
-      "integrity": "sha512-FpeRtJIPa/FMbX/Vb00/QeKvT8AMGMyTJ3jkg1yTwZ9g5uGmvQKJtBHO8+yPoZyj71YrPud7LCdMBy5ihdczqg==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.99.0.tgz",
+      "integrity": "sha512-ZwKAWzvVCw51yjmIf5484KgsAzZAlGTM4uy9lki4PjAYxcEME2Xf93d31LhHzgUAr2JI79H+cNKoRjDHdv1BXQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10202,6 +10286,12 @@
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.7.tgz",
+      "integrity": "sha512-QW2fnwDGKGc9DwQUGLbmMOz8G48UZK7PVNJPcOUql1b8jubKx4/eMHNP5mGqr6tYlJNDG1g10Lx2U/qPzL6zwQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -11096,9 +11186,9 @@
       }
     },
     "node_modules/isomorphic-dompurify": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.25.0.tgz",
-      "integrity": "sha512-bcpJzu9DOjN21qaCVpcoCwUX1ytpvA6EFqCK5RNtPg5+F0Jz9PX50jl6jbEicBNeO87eDDfC7XtPs4zjDClZJg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.26.0.tgz",
+      "integrity": "sha512-nZmoK4wKdzPs5USq4JHBiimjdKSVAOm2T1KyDoadtMPNXYHxiENd19ou4iU/V4juFM6LVgYQnpxCYmxqNP4Obw==",
       "license": "MIT",
       "dependencies": {
         "dompurify": "^3.2.6",
@@ -11787,6 +11877,22 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "license": "CC0-1.0"
     },
+    "node_modules/media-chrome": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.11.1.tgz",
+      "integrity": "sha512-+2niDc4qOwlpFAjwxg1OaizK/zKV6y7QqGm4nBFEVlSaG0ZBgOmfc4IXAPiirZqAlZGaFFUaMqCl1SpGU0/naA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vercel/edge": "^1.2.1",
+        "ce-la-react": "^0.3.0"
+      }
+    },
+    "node_modules/media-tracks": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.3.tgz",
+      "integrity": "sha512-9P2FuUHnZZ3iji+2RQk7Zkh5AmZTnOG5fODACnjhCVveX1McY3jmCRHofIEI+yTBqplz7LXy48c7fQ3Uigp88w==",
+      "license": "MIT"
+    },
     "node_modules/mendoza": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.8.tgz",
@@ -11860,18 +11966,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -12092,18 +12186,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.22.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.22.0.tgz",
-      "integrity": "sha512-ooH7+/BPw9gOsL9VtPhEJHE2m4ltnhMlcGMhEqA0YGNhKof7jdaszvsyThXI6LVIKshJUZ9/CP6HNqQhJfV7kw==",
+      "version": "12.23.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.2.tgz",
+      "integrity": "sha512-73j6xDHX/NvVh5L5oS1ouAVnshsvmApOq4F3VZo5MkYSD/YVsVLal4Qp9wvVgJM9uU2bLZyc0Sn8B9c/MMKk4g==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.19.0"
+        "motion-utils": "^12.23.2"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.19.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
-      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "version": "12.23.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.2.tgz",
+      "integrity": "sha512-cIEXlBlXAOUyiAtR0S+QPQUM9L3Diz23Bo+zM420NvSd/oPQJwg6U+rT+WRTpp0rizMsBGQOsAwhWIfglUcZfA==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -12120,6 +12214,12 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/mux-embed": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
+      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w==",
+      "license": "MIT"
     },
     "node_modules/nano-pubsub": {
       "version": "3.0.0",
@@ -12900,12 +13000,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -12960,6 +13060,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/player.style": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.1.9.tgz",
+      "integrity": "sha512-aFmIhHMrnAP8YliFYFMnRw+5AlHqBvnqWy4vHGo2kFxlC+XjmTXqgg62qSxlE8ubAY83c0ViEZGYglSJi6mGCA==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site",
+        "examples/*",
+        "scripts/*",
+        "themes/*"
+      ],
+      "dependencies": {
+        "media-chrome": "~4.11.0"
       }
     },
     "node_modules/pluralize-esm": {
@@ -13650,18 +13766,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -13913,9 +14017,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.44.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.2.tgz",
-      "integrity": "sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.0.tgz",
+      "integrity": "sha512-WLjEcJRIo7i3WDDgOIJqVI2d+lAC3EwvOGy+Xfq6hs+GQuAA4Di/H72xmXkOhrIWFg2PFYSKZYfH0f4vfKXN4A==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -13928,26 +14032,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.44.2",
-        "@rollup/rollup-android-arm64": "4.44.2",
-        "@rollup/rollup-darwin-arm64": "4.44.2",
-        "@rollup/rollup-darwin-x64": "4.44.2",
-        "@rollup/rollup-freebsd-arm64": "4.44.2",
-        "@rollup/rollup-freebsd-x64": "4.44.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.44.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.44.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.44.2",
-        "@rollup/rollup-linux-arm64-musl": "4.44.2",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.44.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.44.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.44.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.44.2",
-        "@rollup/rollup-linux-x64-gnu": "4.44.2",
-        "@rollup/rollup-linux-x64-musl": "4.44.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.44.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.44.2",
-        "@rollup/rollup-win32-x64-msvc": "4.44.2",
+        "@rollup/rollup-android-arm-eabi": "4.45.0",
+        "@rollup/rollup-android-arm64": "4.45.0",
+        "@rollup/rollup-darwin-arm64": "4.45.0",
+        "@rollup/rollup-darwin-x64": "4.45.0",
+        "@rollup/rollup-freebsd-arm64": "4.45.0",
+        "@rollup/rollup-freebsd-x64": "4.45.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.45.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.45.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.45.0",
+        "@rollup/rollup-linux-arm64-musl": "4.45.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.45.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.45.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.45.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.45.0",
+        "@rollup/rollup-linux-x64-gnu": "4.45.0",
+        "@rollup/rollup-linux-x64-musl": "4.45.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.45.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.45.0",
+        "@rollup/rollup-win32-x64-msvc": "4.45.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -14145,9 +14249,9 @@
       "license": "MIT"
     },
     "node_modules/sanity": {
-      "version": "3.97.1",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.97.1.tgz",
-      "integrity": "sha512-37cyYHTkbsC6xryVyh6ChqzQrG37x3bN+LfgNzH1E4ZmAGkvu0QMWtJ4NQjw9SL6DBCnp8OSitk+10sK4rd/6g==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.99.0.tgz",
+      "integrity": "sha512-uNo8bEC6w4j87d6mUMpkTIjRR/bTtF+SKmvRl0XP7ZCjds9oK2+t4txL1Rr0VmV5KnCFZJhq8sP7aVJN5PPD5w==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -14155,18 +14259,19 @@
         "@dnd-kit/sortable": "^7.0.2",
         "@dnd-kit/utilities": "^3.2.2",
         "@juggle/resize-observer": "^3.4.0",
-        "@portabletext/block-tools": "^1.1.34",
-        "@portabletext/editor": "^1.55.15",
+        "@mux/mux-player-react": "^3.4.0",
+        "@portabletext/block-tools": "^1.1.38",
+        "@portabletext/editor": "^1.57.5",
         "@portabletext/react": "^3.2.1",
         "@portabletext/toolkit": "^2.0.17",
         "@rexxars/react-json-inspector": "^9.0.1",
         "@sanity/asset-utils": "^2.2.1",
         "@sanity/bifur-client": "^0.4.1",
-        "@sanity/cli": "3.97.1",
+        "@sanity/cli": "3.99.0",
         "@sanity/client": "^7.6.0",
         "@sanity/color": "^3.0.6",
         "@sanity/comlink": "^3.0.5",
-        "@sanity/diff": "3.97.1",
+        "@sanity/diff": "3.99.0",
         "@sanity/diff-match-patch": "^3.2.0",
         "@sanity/diff-patch": "^5.0.0",
         "@sanity/eventsource": "^5.0.2",
@@ -14179,16 +14284,16 @@
         "@sanity/logos": "^2.2.1",
         "@sanity/media-library-types": "^1.0.0",
         "@sanity/message-protocol": "^0.13.0",
-        "@sanity/migrate": "3.97.1",
-        "@sanity/mutator": "3.97.1",
+        "@sanity/migrate": "3.99.0",
+        "@sanity/mutator": "3.99.0",
         "@sanity/presentation-comlink": "^1.0.21",
         "@sanity/preview-url-secret": "^2.1.11",
-        "@sanity/schema": "3.97.1",
+        "@sanity/schema": "3.99.0",
         "@sanity/sdk": "0.0.0-alpha.25",
         "@sanity/telemetry": "^0.8.0",
-        "@sanity/types": "3.97.1",
-        "@sanity/ui": "^2.16.2",
-        "@sanity/util": "3.97.1",
+        "@sanity/types": "3.99.0",
+        "@sanity/ui": "^2.16.4",
+        "@sanity/util": "3.99.0",
         "@sanity/uuid": "^3.0.2",
         "@sentry/react": "^8.55.0",
         "@tanstack/react-table": "^8.21.3",
@@ -14213,7 +14318,7 @@
         "dataloader": "^2.2.3",
         "date-fns": "^2.26.1",
         "debug": "^4.3.4",
-        "esbuild": "0.25.5",
+        "esbuild": "0.25.6",
         "esbuild-register": "^3.6.0",
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
@@ -14249,6 +14354,7 @@
         "path-to-regexp": "^6.3.0",
         "peek-stream": "^1.1.3",
         "pirates": "^4.0.0",
+        "player.style": "^0.1.9",
         "pluralize-esm": "^9.0.2",
         "polished": "^4.2.2",
         "preferred-pm": "^4.1.1",
@@ -15358,6 +15464,32 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -15671,15 +15803,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.35.1.tgz",
-      "integrity": "sha512-xslJjFzhOmHYQzSB/QTeASAHbjmxOGEP6Coh93TXmUBFQoJ1VU35UHIDmG06Jd6taf3wqqC1ntBnCMeymy5Ovw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.36.0.tgz",
+      "integrity": "sha512-fTCqxthY+h9QbEgSIBfL9iV6CvKDFuoxg6bHPNpJ9HIUzS+jy2lCEyCmGyZRWEBSaykqcDPf1SJ+BfCI8DRopA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.35.1",
-        "@typescript-eslint/parser": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1"
+        "@typescript-eslint/eslint-plugin": "8.36.0",
+        "@typescript-eslint/parser": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -16135,6 +16267,32 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vite/node_modules/postcss": {
@@ -16691,9 +16849,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.75",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.75.tgz",
-      "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/sanity/package.json
+++ b/sanity/package.json
@@ -15,10 +15,10 @@
     "sanity"
   ],
   "dependencies": {
-    "@sanity/vision": "^3.97.1",
+    "@sanity/vision": "^3.99.0",
     "react": "^19.1",
     "react-dom": "^19.1",
-    "sanity": "^3.97.1",
+    "sanity": "^3.99.0",
     "styled-components": "^6.1.18"
   },
   "devDependencies": {

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -1,5 +1,7 @@
 import news from './news'
 import testimonials from './testimonials'
 import blog from './blog'
+import serviceCategory from './serviceCategory'
+import serviceDetail from './serviceDetail'
 
-export const schemaTypes = [news, testimonials, blog]
+export const schemaTypes = [news, testimonials, blog, serviceCategory, serviceDetail]

--- a/sanity/schemaTypes/serviceCategory.ts
+++ b/sanity/schemaTypes/serviceCategory.ts
@@ -2,6 +2,8 @@
 // 目的: 行政書士サイトの階層2ページ「カテゴリー一覧」用のSanityスキーマ定義
 // 注意: 順序制御のため orderRank, SEO強化のため metaTitle, metaDescription, ogImage を含む
 
+import { Rule } from 'sanity'
+
 export default {
   name: 'serviceCategory',
   type: 'document',
@@ -11,7 +13,7 @@ export default {
       name: 'title',
       type: 'string',
       title: 'カテゴリー名',
-      validation: Rule => Rule.required(),
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'slug',
@@ -21,7 +23,7 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-      validation: Rule => Rule.required(),
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'icon',

--- a/sanity/schemaTypes/serviceCategory.ts
+++ b/sanity/schemaTypes/serviceCategory.ts
@@ -1,0 +1,93 @@
+// ファイル名: schemas/serviceCategory.ts
+// 目的: 行政書士サイトの階層2ページ「カテゴリー一覧」用のSanityスキーマ定義
+// 注意: 順序制御のため orderRank, SEO強化のため metaTitle, metaDescription, ogImage を含む
+
+export default {
+  name: 'serviceCategory',
+  type: 'document',
+  title: 'サービスカテゴリ',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      title: 'カテゴリー名',
+      validation: Rule => Rule.required(),
+    },
+    {
+      name: 'slug',
+      type: 'slug',
+      title: 'スラッグ（URL）',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+      validation: Rule => Rule.required(),
+    },
+    {
+      name: 'icon',
+      type: 'image',
+      title: 'トップページ用アイコン',
+    },
+    {
+      name: 'image',
+      type: 'image',
+      title: '階層1カード用画像',
+    },
+    {
+      name: 'catchphrase',
+      type: 'string',
+      title: 'キャッチコピー',
+    },
+    {
+      name: 'expertiseDescription',
+      type: 'array',
+      title: '専門性のアピール',
+      of: [{ type: 'block' }],
+    },
+    {
+      name: 'faq',
+      type: 'array',
+      title: 'よくある質問',
+      of: [
+        {
+          type: 'object',
+          name: 'faqItem',
+          fields: [
+            { name: 'question', type: 'string', title: '質問' },
+            { name: 'answer', type: 'text', title: '回答' },
+          ],
+        },
+      ],
+      options: {
+        sortable: true,
+      },
+    },
+    {
+      name: 'metaTitle',
+      type: 'string',
+      title: 'SEOタイトル',
+    },
+    {
+      name: 'metaDescription',
+      type: 'text',
+      title: 'SEOディスクリプション',
+    },
+    {
+      name: 'ogImage',
+      type: 'image',
+      title: 'OGP画像',
+    },
+    {
+      name: 'orderRank',
+      type: 'number',
+      title: '表示順（小さいほど先頭）',
+    },
+  ],
+  orderings: [
+    {
+      title: '表示順（昇順）',
+      name: 'orderRankAsc',
+      by: [{ field: 'orderRank', direction: 'asc' }],
+    },
+  ],
+};

--- a/sanity/schemaTypes/serviceDetail.ts
+++ b/sanity/schemaTypes/serviceDetail.ts
@@ -1,0 +1,130 @@
+// ファイル名: schemas/serviceDetail.ts
+// 目的: 行政書士サイトの「中項目詳細ページ」用 Sanity スキーマ定義
+// 関連: 各中項目は親カテゴリ（serviceCategory）と関連付けされる
+
+export default {
+  name: 'serviceDetail',
+  type: 'document',
+  title: 'サービス詳細',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      title: 'サービス名',
+      validation: Rule => Rule.required(),
+    },
+    {
+      name: 'slug',
+      type: 'slug',
+      title: 'スラッグ（URL）',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+      validation: Rule => Rule.required(),
+    },
+    {
+      name: 'parentCategory',
+      type: 'reference',
+      to: [{ type: 'serviceCategory' }],
+      title: '親カテゴリ',
+      validation: Rule => Rule.required(),
+    },
+    {
+      name: 'overview',
+      type: 'text',
+      title: 'サービス概要（1〜2文）',
+    },
+    {
+      name: 'target',
+      type: 'string',
+      title: '対象となる方',
+    },
+    {
+      name: 'price',
+      type: 'string',
+      title: '料金目安',
+    },
+    {
+      name: 'problemStatement',
+      type: 'array',
+      title: 'お悩み提起',
+      of: [{ type: 'block' }],
+    },
+    {
+      name: 'serviceMerits',
+      type: 'array',
+      title: '依頼するメリット',
+      of: [{ type: 'block' }],
+    },
+    {
+      name: 'serviceFlow',
+      type: 'array',
+      title: '手続きの流れ',
+      of: [{ type: 'block' }],
+    },
+    {
+      name: 'priceTable',
+      type: 'array',
+      title: '料金表',
+      of: [{ type: 'block' }],
+    },
+    {
+      name: 'requiredDocuments',
+      type: 'array',
+      title: '必要書類一覧',
+      of: [{ type: 'block' }],
+    },
+    {
+      name: 'faq',
+      type: 'array',
+      title: 'よくある質問',
+      of: [
+        {
+          type: 'object',
+          name: 'faqItem',
+          fields: [
+            { name: 'question', type: 'string', title: '質問' },
+            { name: 'answer', type: 'text', title: '回答' },
+          ],
+        },
+      ],
+      options: {
+        sortable: true,
+      },
+    },
+    {
+      name: 'metaTitle',
+      type: 'string',
+      title: 'SEOタイトル',
+    },
+    {
+      name: 'metaDescription',
+      type: 'text',
+      title: 'SEOディスクリプション',
+    },
+    {
+      name: 'ogImage',
+      type: 'image',
+      title: 'OGP画像',
+    },
+    {
+      name: 'orderRank',
+      type: 'number',
+      title: '表示順（小さいほど先頭）',
+    },
+    {
+      name: 'tag',
+      type: 'array',
+      title: 'タグ（複数可）',
+      of: [{ type: 'string' }],
+    },
+  ],
+  orderings: [
+    {
+      title: '表示順（昇順）',
+      name: 'orderRankAsc',
+      by: [{ field: 'orderRank', direction: 'asc' }],
+    },
+  ],
+};

--- a/sanity/schemaTypes/serviceDetail.ts
+++ b/sanity/schemaTypes/serviceDetail.ts
@@ -2,6 +2,8 @@
 // 目的: 行政書士サイトの「中項目詳細ページ」用 Sanity スキーマ定義
 // 関連: 各中項目は親カテゴリ（serviceCategory）と関連付けされる
 
+import { Rule } from 'sanity'
+
 export default {
   name: 'serviceDetail',
   type: 'document',
@@ -11,7 +13,7 @@ export default {
       name: 'title',
       type: 'string',
       title: 'サービス名',
-      validation: Rule => Rule.required(),
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'slug',
@@ -21,14 +23,14 @@ export default {
         source: 'title',
         maxLength: 96,
       },
-      validation: Rule => Rule.required(),
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'parentCategory',
       type: 'reference',
       to: [{ type: 'serviceCategory' }],
       title: '親カテゴリ',
-      validation: Rule => Rule.required(),
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'overview',

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -2,7 +2,7 @@
 
 import { sanityClient } from '@/lib/sanity.client';
 import { categoryPageQuery, categorySlugsQuery } from '@/lib/queries';
-import { ServiceCategory } from '@/types';
+import { ServiceCategory } from '@/lib/types';
 import { PortableText } from '@portabletext/react';
 import FaqAccordion from '@/components/FaqAccordion';
 import Breadcrumbs from '@/components/Breadcrumbs';

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -1,0 +1,85 @@
+// ファイル名: app/(public)/services/[category]/page.tsx
+
+import { sanityClient } from '@/lib/sanity.client';
+import { categoryPageQuery, categorySlugsQuery } from '@/lib/queries';
+import { ServiceCategory } from '@/types';
+import { PortableText } from '@portabletext/react';
+import FaqAccordion from '@/components/FaqAccordion';
+import Breadcrumbs from '@/components/Breadcrumbs';
+import CtaBanner from '@/components/CtaBanner';
+import ServiceTable from '@/components/ServiceTable';
+
+type Props = {
+  params: { category: string };
+};
+
+export async function generateStaticParams() {
+  const slugs = await sanityClient.fetch(categorySlugsQuery);
+  return slugs.map((slug: { slug: string }) => ({ category: slug.slug }));
+}
+
+export async function generateMetadata({ params }: Props) {
+  return {
+    title: `${params.category} | サービスカテゴリ`,
+  };
+}
+
+export default async function CategoryPage({ params }: Props) {
+  const data: ServiceCategory = await sanityClient.fetch(categoryPageQuery, {
+    slug: params.category,
+  });
+
+  if (!data) return <div>ページが見つかりません</div>;
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-12 space-y-16">
+      {/* パンくず */}
+      <Breadcrumbs
+        items={[
+          { label: 'ホーム', href: '/' },
+          { label: 'サービス案内', href: '/services' },
+          { label: data.title },
+        ]}
+      />
+
+      {/* Hero セクション */}
+      <section>
+        <h1 className="text-3xl font-bold mb-4">
+          【専門家がサポート】{data.title}のご案内
+        </h1>
+        {data.expertiseDescription && (
+          <PortableText value={data.expertiseDescription} />
+        )}
+      </section>
+
+      {/* 中項目テーブル */}
+      {data.services && data.services.length > 0 && (
+        <ServiceTable services={data.services} categorySlug={data.slug} />
+      )}
+
+      {/* FAQ アコーディオン */}
+      {data.faq && data.faq.length > 0 && (
+        <section>
+          <h2 className="text-2xl font-semibold mb-4">よくあるご質問</h2>
+          <FaqAccordion items={data.faq} />
+        </section>
+      )}
+
+      {/* 実績紹介バナー */}
+      <div className="text-center py-8 bg-gray-100 rounded-xl">
+        <a
+          href={`/cases?category=${data.slug}`}
+          className="text-blue-700 hover:underline font-medium"
+        >
+          {data.title}に関する実績を見る ＞
+        </a>
+      </div>
+
+      {/* CTA */}
+      <CtaBanner
+        text={`${data.title}について無料で相談する`}
+        href={`/contact?service=${data.slug}`}
+      />
+    </div>
+  );
+}

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -10,7 +10,7 @@ import CtaBanner from '@/components/CtaBanner';
 import ServiceTable from '@/components/ServiceTable';
 
 type Props = {
-  params: { category: string };
+  params: Promise<{ category: string }>;
 };
 
 export async function generateStaticParams() {
@@ -19,14 +19,16 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: Props) {
+  const { category } = await params;
   return {
-    title: `${params.category} | サービスカテゴリ`,
+    title: `${category} | サービスカテゴリ`,
   };
 }
 
 export default async function CategoryPage({ params }: Props) {
+  const { category } = await params;
   const data: ServiceCategory = await sanityClient.fetch(categoryPageQuery, {
-    slug: params.category,
+    slug: category,
   });
 
   if (!data) return <div>ページが見つかりません</div>;

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -14,6 +14,11 @@ type Props = {
 };
 
 export async function generateStaticParams() {
+  // ビルド時はSanityクエリをスキップ
+  if (!process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.NEXT_PUBLIC_SANITY_PROJECT_ID === 'dummy-project-id') {
+    return [];
+  }
+  
   const slugs = await sanityClient.fetch(categorySlugsQuery);
   return slugs.map((slug: { slug: string }) => ({ category: slug.slug }));
 }
@@ -27,6 +32,16 @@ export async function generateMetadata({ params }: Props) {
 
 export default async function CategoryPage({ params }: Props) {
   const { category } = await params;
+  
+  // Sanityが設定されていない場合のフォールバック
+  if (!process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.NEXT_PUBLIC_SANITY_PROJECT_ID === 'dummy-project-id') {
+    return (
+      <div className="max-w-6xl mx-auto px-4 py-12">
+        <p className="text-gray-600">Sanityの設定が必要です。環境変数を設定してください。</p>
+      </div>
+    );
+  }
+  
   const data: ServiceCategory = await sanityClient.fetch(categoryPageQuery, {
     slug: category,
   });

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumbs({ items }: BreadcrumbsProps) {
+  return (
+    <nav aria-label="パンくずリスト" className="text-sm">
+      <ol className="flex items-center space-x-2">
+        {items.map((item, index) => (
+          <li key={index} className="flex items-center">
+            {index > 0 && <span className="mx-2 text-gray-400">{'>'}</span>}
+            {item.href ? (
+              <Link
+                href={item.href}
+                className="text-blue-600 hover:text-blue-800 hover:underline"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span className="text-gray-700">{item.label}</span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/CtaBanner.tsx
+++ b/src/components/CtaBanner.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+interface CtaBannerProps {
+  text: string;
+  href: string;
+  buttonText?: string;
+}
+
+export default function CtaBanner({ text, href, buttonText = 'お問い合わせ' }: CtaBannerProps) {
+  return (
+    <div className="bg-blue-600 text-white rounded-xl p-8 text-center">
+      <h3 className="text-2xl font-bold mb-4">{text}</h3>
+      <Link
+        href={href}
+        className="inline-block bg-white text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors"
+      >
+        {buttonText}
+      </Link>
+    </div>
+  );
+}

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from 'react';
+import { FaqItem } from '@/lib/types';
+
+interface FaqAccordionProps {
+  items: FaqItem[];
+}
+
+export default function FaqAccordion({ items }: FaqAccordionProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const toggleItem = (index: number) => {
+    setOpenIndex(openIndex === index ? null : index);
+  };
+
+  return (
+    <div className="space-y-4">
+      {items.map((item, index) => (
+        <div key={index} className="border border-gray-200 rounded-lg">
+          <button
+            className="w-full px-6 py-4 text-left flex justify-between items-center hover:bg-gray-50 transition-colors"
+            onClick={() => toggleItem(index)}
+          >
+            <span className="font-medium text-gray-900">{item.question}</span>
+            <svg
+              className={`w-5 h-5 text-gray-500 transition-transform ${
+                openIndex === index ? 'rotate-180' : ''
+              }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+          {openIndex === index && (
+            <div className="px-6 py-4 border-t border-gray-200">
+              <p className="text-gray-700">{item.answer}</p>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ServiceTable.tsx
+++ b/src/components/ServiceTable.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import { ServiceDetailLite } from '@/lib/types';
+
+interface ServiceTableProps {
+  services: ServiceDetailLite[];
+  categorySlug: string;
+}
+
+export default function ServiceTable({ services, categorySlug }: ServiceTableProps) {
+  return (
+    <section>
+      <h2 className="text-2xl font-semibold mb-6">サービス一覧</h2>
+      <div className="bg-white shadow-sm rounded-lg overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                サービス名
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                対象者
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                料金目安
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                詳細
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {services.map((service) => (
+              <tr key={service._id} className="hover:bg-gray-50">
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm font-medium text-gray-900">{service.title}</div>
+                  <div className="text-sm text-gray-500">{service.overview}</div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {service.target}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {service.price}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                  <Link
+                    href={`/services/${categorySlug}/${service.slug}`}
+                    className="text-blue-600 hover:text-blue-900"
+                  >
+                    詳細を見る →
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,0 +1,117 @@
+// ファイル名: lib/queries.ts
+// 目的: Sanity CMSからデータを取得するためのGROQクエリ定義ファイル
+// 対象: serviceCategory および serviceDetail コレクション
+
+// 1. すべてのカテゴリーのスラッグを取得（動的ルート生成用）
+export const allCategorySlugsQuery = `
+  *[_type == "serviceCategory" && defined(slug.current)] {
+    "slug": slug.current
+  }
+`;
+
+// 2. すべてのサービス詳細のスラッグを取得（動的ルート生成用）
+export const allServiceDetailSlugsQuery = `
+  *[_type == "serviceDetail" && defined(slug.current)] {
+    "slug": slug.current,
+    "categorySlug": parentCategory->slug.current
+  }
+`;
+
+// 3. サービスカテゴリー一覧を取得（階層1ページ用）
+export const allServiceCategoriesQuery = `
+  *[_type == "serviceCategory"] | order(orderRank asc, _createdAt asc) {
+    _id,
+    title,
+    "slug": slug.current,
+    catchphrase,
+    "iconUrl": icon.asset->url,
+    "imageUrl": image.asset->url
+  }
+`;
+
+// 4. 特定カテゴリーの詳細と関連サービスを取得（階層2ページ用）
+export const serviceCategoryWithDetailsQuery = `
+  *[_type == "serviceCategory" && slug.current == $slug][0] {
+    _id,
+    title,
+    "slug": slug.current,
+    catchphrase,
+    expertiseDescription,
+    faq,
+    metaTitle,
+    metaDescription,
+    "ogImageUrl": ogImage.asset->url,
+    "iconUrl": icon.asset->url,
+    "imageUrl": image.asset->url,
+    "services": *[_type == "serviceDetail" && references(^._id)] | order(orderRank asc, _createdAt asc) {
+      _id,
+      title,
+      "slug": slug.current,
+      overview,
+      target,
+      price
+    }
+  }
+`;
+
+// 5. 特定サービス詳細を取得（階層3ページ用）
+export const serviceDetailQuery = `
+  *[_type == "serviceDetail" && slug.current == $slug][0] {
+    _id,
+    title,
+    "slug": slug.current,
+    overview,
+    target,
+    price,
+    problemStatement,
+    serviceMerits,
+    serviceFlow,
+    priceTable,
+    requiredDocuments,
+    faq,
+    metaTitle,
+    metaDescription,
+    "ogImageUrl": ogImage.asset->url,
+    tag,
+    "parentCategory": parentCategory-> {
+      _id,
+      title,
+      "slug": slug.current
+    }
+  }
+`;
+
+// 6. トップページ用：カテゴリー一覧（シンプル版）
+export const topPageCategoriesQuery = `
+  *[_type == "serviceCategory"] | order(orderRank asc, _createdAt asc) {
+    _id,
+    title,
+    "slug": slug.current,
+    "iconUrl": icon.asset->url
+  }
+`;
+
+// 7. 関連サービスを取得（同じカテゴリー内の他のサービス）
+export const relatedServicesQuery = `
+  *[_type == "serviceDetail" && parentCategory._ref == $categoryId && _id != $currentServiceId] | order(orderRank asc, _createdAt asc)[0...5] {
+    _id,
+    title,
+    "slug": slug.current,
+    overview
+  }
+`;
+
+// 8. サイトマップ用：全カテゴリーと全サービスのURL
+export const sitemapQuery = `
+  {
+    "categories": *[_type == "serviceCategory"] {
+      "slug": slug.current,
+      _updatedAt
+    },
+    "services": *[_type == "serviceDetail"] {
+      "slug": slug.current,
+      "categorySlug": parentCategory->slug.current,
+      _updatedAt
+    }
+  }
+`;

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -3,7 +3,7 @@
 // 対象: serviceCategory および serviceDetail コレクション
 
 // 1. すべてのカテゴリーのスラッグを取得（動的ルート生成用）
-export const allCategorySlugsQuery = `
+export const categorySlugsQuery = `
   *[_type == "serviceCategory" && defined(slug.current)] {
     "slug": slug.current
   }
@@ -30,7 +30,7 @@ export const allServiceCategoriesQuery = `
 `;
 
 // 4. 特定カテゴリーの詳細と関連サービスを取得（階層2ページ用）
-export const serviceCategoryWithDetailsQuery = `
+export const categoryPageQuery = `
   *[_type == "serviceCategory" && slug.current == $slug][0] {
     _id,
     title,

--- a/src/lib/sanity.client.ts
+++ b/src/lib/sanity.client.ts
@@ -1,0 +1,11 @@
+// ファイル名: lib/sanity.client.ts
+// 目的: Sanity API との接続クライアント設定
+
+import { createClient } from 'next-sanity';
+
+export const sanityClient = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '', // .env に設定
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || 'production',
+  apiVersion: '2024-07-01', // バージョンは固定で OK（最近の日付）
+  useCdn: true, // SSG 時は true で高速化（草稿を表示しない）
+});

--- a/src/lib/sanity.client.ts
+++ b/src/lib/sanity.client.ts
@@ -3,9 +3,18 @@
 
 import { createClient } from 'next-sanity';
 
+// 環境変数が設定されていない場合は、ダミーの値を使用
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || 'dummy-project-id';
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production';
+
+// プロジェクトIDが設定されていない場合の警告
+if (!process.env.NEXT_PUBLIC_SANITY_PROJECT_ID) {
+  console.warn('⚠️ NEXT_PUBLIC_SANITY_PROJECT_ID is not set. Please set it in your environment variables.');
+}
+
 export const sanityClient = createClient({
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || '', // .env に設定
-  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || 'production',
+  projectId,
+  dataset,
   apiVersion: '2024-07-01', // バージョンは固定で OK（最近の日付）
   useCdn: true, // SSG 時は true で高速化（草稿を表示しない）
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,13 +15,35 @@ export interface ServiceDetailLite {
   price: string;
 }
 
+// Sanity Image Asset型定義
+export interface SanityImageAsset {
+  _id: string;
+  url: string;
+}
+
+// Portable Text Block型定義
+export interface PortableTextBlock {
+  _type: 'block';
+  children: Array<{
+    _type: 'span';
+    text: string;
+    marks?: string[];
+  }>;
+  style?: string;
+  markDefs?: Array<{
+    _key: string;
+    _type: string;
+    [key: string]: unknown;
+  }>;
+}
+
 export interface ServiceCategory {
   title: string;
   slug: string;
-  icon?: any; // Sanity Image Object (修正可)
-  image?: any; // Sanity Image Object (修正可)
+  icon?: SanityImageAsset;
+  image?: SanityImageAsset;
   catchphrase?: string;
-  expertiseDescription?: any; // Portable Text（Block Content）
+  expertiseDescription?: PortableTextBlock[];
   faq?: FaqItem[];
   services?: ServiceDetailLite[];
 }
@@ -32,16 +54,16 @@ export interface ServiceDetail {
   overview?: string;
   target?: string;
   price?: string;
-  problemStatement?: any;
-  serviceMerits?: any;
-  serviceFlow?: any;
-  priceTable?: any;
-  requiredDocuments?: any;
+  problemStatement?: PortableTextBlock[];
+  serviceMerits?: PortableTextBlock[];
+  serviceFlow?: PortableTextBlock[];
+  priceTable?: PortableTextBlock[];
+  requiredDocuments?: PortableTextBlock[];
   faq?: FaqItem[];
   tag?: string[];
   metaTitle?: string;
   metaDescription?: string;
-  ogImage?: any;
+  ogImage?: SanityImageAsset;
   category?: {
     title: string;
     slug: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,49 @@
+// ファイル名: types.ts
+// 目的: GROQクエリで取得したSanityデータの型定義
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+export interface ServiceDetailLite {
+  _id: string;
+  title: string;
+  slug: string;
+  overview: string;
+  target: string;
+  price: string;
+}
+
+export interface ServiceCategory {
+  title: string;
+  slug: string;
+  icon?: any; // Sanity Image Object (修正可)
+  image?: any; // Sanity Image Object (修正可)
+  catchphrase?: string;
+  expertiseDescription?: any; // Portable Text（Block Content）
+  faq?: FaqItem[];
+  services?: ServiceDetailLite[];
+}
+
+export interface ServiceDetail {
+  title: string;
+  slug: string;
+  overview?: string;
+  target?: string;
+  price?: string;
+  problemStatement?: any;
+  serviceMerits?: any;
+  serviceFlow?: any;
+  priceTable?: any;
+  requiredDocuments?: any;
+  faq?: FaqItem[];
+  tag?: string[];
+  metaTitle?: string;
+  metaDescription?: string;
+  ogImage?: any;
+  category?: {
+    title: string;
+    slug: string;
+  };
+}


### PR DESCRIPTION
- Sanityスキーマを追加
  - serviceCategory: サービスカテゴリ用スキーマ
  - serviceDetail: サービス詳細用スキーマ
- クエリとタイプ定義を追加
  - queries.ts: GROQクエリ定義
  - types.ts: TypeScript型定義
  - sanity.client.ts: Sanityクライアント設定
- サービスカテゴリページ（動的ルート）を実装
- .env.localテンプレートを追加

🤖 Generated with [Claude Code](https://claude.ai/code)