### PR TITLE
ホームページのサービス一覧をSanityと連携

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,16 @@ import Link from "next/link";
 import { sanityClient } from '@/lib/sanity.client';
 import { topPageCategoriesQuery } from '@/lib/queries';
 
+// 型定義
+interface ServiceCategoryItem {
+  _id: string;
+  title: string;
+  slug: string;
+  iconUrl?: string;
+}
+
 // Sanityからサービスカテゴリを取得
-async function getServiceCategories() {
+async function getServiceCategories(): Promise<ServiceCategoryItem[]> {
   // 環境変数が設定されていない場合は空配列を返す
   if (!process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.NEXT_PUBLIC_SANITY_PROJECT_ID === 'dummy-project-id') {
     return [];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -166,7 +166,32 @@ export default async function Home() {
               豊富な経験と専門知識で、お客様のニーズにお応えします
             </p>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          
+          {/* Sanityからのデータがある場合は動的に表示 */}
+          {serviceCategories.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+              {serviceCategories.map((category) => (
+                <Link
+                  key={category._id}
+                  href={`/services/${category.slug}`}
+                  className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center block"
+                >
+                  <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                    {category.iconUrl ? (
+                      <img src={category.iconUrl} alt={category.title} className="w-6 h-6" />
+                    ) : (
+                      <svg className="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </svg>
+                    )}
+                  </div>
+                  <h3 className="text-lg font-semibold text-gray-900">{category.title}</h3>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            /* Sanityが設定されていない場合は既存のハードコーディングされたサービスを表示 */
+            <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
             
             {/* 外国人関連業務 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -278,7 +278,7 @@ export default async function Home() {
               </div>
               <h3 className="text-lg font-semibold text-gray-900">その他の業務</h3>
             </div>
-            </div>
+          </div>
           )}
         </div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,24 @@
 import Link from "next/link";
+import { sanityClient } from '@/lib/sanity.client';
+import { topPageCategoriesQuery } from '@/lib/queries';
 
-export default function Home() {
+// Sanityからサービスカテゴリを取得
+async function getServiceCategories() {
+  // 環境変数が設定されていない場合は空配列を返す
+  if (!process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.NEXT_PUBLIC_SANITY_PROJECT_ID === 'dummy-project-id') {
+    return [];
+  }
+  
+  try {
+    return await sanityClient.fetch(topPageCategoriesQuery);
+  } catch (error) {
+    console.error('Failed to fetch service categories:', error);
+    return [];
+  }
+}
+
+export default async function Home() {
+  const serviceCategories = await getServiceCategories();
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
@@ -260,8 +278,8 @@ export default function Home() {
               </div>
               <h3 className="text-lg font-semibold text-gray-900">その他の業務</h3>
             </div>
-
-          </div>
+            </div>
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
- Sanityからサービスカテゴリを取得する機能を追加
- サービスボックスをクリックすると動的ルート(/services/[category])へ遷移
- Sanity未設定時は既存のハードコーディングされたサービスを表示

🤖 Generated with [Claude Code](https://claude.ai/code)