### PR TITLE
feat: Sanityスキーマの表示順制御を強化

### DIFF
--- a/sanity/schemaTypes/serviceCategory.ts
+++ b/sanity/schemaTypes/serviceCategory.ts
@@ -10,6 +10,16 @@ export default {
   title: 'サービスカテゴリ',
   fields: [
     {
+      name: 'orderRank',
+      type: 'number',
+      title: '表示順',
+      description: '小さい数字が上位に表示されます',
+      options: {
+        isHighlighted: true,
+      },
+      validation: (Rule: Rule) => Rule.required().integer().min(0),
+    },
+    {
       name: 'title',
       type: 'string',
       title: 'カテゴリー名',
@@ -78,11 +88,6 @@ export default {
       name: 'ogImage',
       type: 'image',
       title: 'OGP画像',
-    },
-    {
-      name: 'orderRank',
-      type: 'number',
-      title: '表示順（小さいほど先頭）',
     },
   ],
   orderings: [

--- a/sanity/schemaTypes/serviceDetail.ts
+++ b/sanity/schemaTypes/serviceDetail.ts
@@ -10,6 +10,16 @@ export default {
   title: 'サービス詳細',
   fields: [
     {
+      name: 'orderRank',
+      type: 'number',
+      title: '表示順',
+      description: '小さい数字が上位に表示されます',
+      options: {
+        isHighlighted: true,
+      },
+      validation: (Rule: Rule) => Rule.required().integer().min(0),
+    },
+    {
       name: 'title',
       type: 'string',
       title: 'サービス名',
@@ -109,11 +119,6 @@ export default {
       name: 'ogImage',
       type: 'image',
       title: 'OGP画像',
-    },
-    {
-      name: 'orderRank',
-      type: 'number',
-      title: '表示順（小さいほど先頭）',
     },
     {
       name: 'tag',


### PR DESCRIPTION
- orderRankフィールドをtitleの前に移動して視認性を向上
- isHighlightedオプションを追加してCMS UIで目立つように
- バリデーションを追加（必須、整数、0以上）
- 重複したorderRankフィールドを削除

🤖 Generated with [Claude Code](https://claude.ai/code)