### PR TITLE
feat: パンくずリストにSEO構造化データ(JSON-LD)を実装

### DIFF
--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Header from "@/components/Header";
+import Breadcrumbs from "@/components/Breadcrumbs";
 import { sanityClient } from '@/lib/sanity.client';
 import { allServiceCategoriesQuery } from '@/lib/queries';
 import { ServiceCategory } from '@/lib/types';
@@ -40,6 +41,13 @@ export default async function Services() {
       {/* Services Content */}
       <section className="py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          {/* パンくずリスト */}
+          <Breadcrumbs
+            items={[
+              { label: 'ホーム', href: '/' },
+              { label: 'サービス総合案内' }
+            ]}
+          />
           {/* Sanityからのデータがある場合は動的に表示 */}
           {categories.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Script from 'next/script';
 
 interface BreadcrumbItem {
   label: string;
@@ -7,28 +8,50 @@ interface BreadcrumbItem {
 
 interface BreadcrumbsProps {
   items: BreadcrumbItem[];
+  includeJsonLd?: boolean;
 }
 
-export default function Breadcrumbs({ items }: BreadcrumbsProps) {
+export default function Breadcrumbs({ items, includeJsonLd = true }: BreadcrumbsProps) {
+  // JSON-LD構造化データの生成
+  const jsonLd = includeJsonLd ? {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.label,
+      ...(item.href && { item: `${process.env.NEXT_PUBLIC_SITE_URL || ''}${item.href}` }),
+    })),
+  } : null;
+
   return (
-    <nav aria-label="パンくずリスト" className="text-sm">
-      <ol className="flex items-center space-x-2">
-        {items.map((item, index) => (
-          <li key={index} className="flex items-center">
-            {index > 0 && <span className="mx-2 text-gray-400">{'>'}</span>}
-            {item.href ? (
-              <Link
-                href={item.href}
-                className="text-blue-600 hover:text-blue-800 hover:underline"
-              >
-                {item.label}
-              </Link>
-            ) : (
-              <span className="text-gray-700">{item.label}</span>
-            )}
-          </li>
-        ))}
-      </ol>
-    </nav>
+    <>
+      {jsonLd && (
+        <Script
+          id="breadcrumb-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
+      <nav aria-label="パンくずリスト" className="text-sm mb-6">
+        <ol className="flex flex-wrap items-center">
+          {items.map((item, index) => (
+            <li key={index} className="flex items-center">
+              {index > 0 && <span className="mx-2 text-gray-400">{'>'}</span>}
+              {item.href ? (
+                <Link
+                  href={item.href}
+                  className="text-blue-600 hover:text-blue-800 hover:underline"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span className="text-gray-700">{item.label}</span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+    </>
   );
 }


### PR DESCRIPTION
- BreadcrumbsコンポーネントにJSON-LD構造化データを追加
- Schema.org BreadcrumbList形式に準拠した実装
- 環境変数NEXT_PUBLIC_SITE_URLを使用してURLを生成
- サービス一覧ページにパンくずリストを追加
- includeJsonLdプロパティで構造化データのオン/オフ制御が可能

🤖 Generated with [Claude Code](https://claude.ai/code)