### PR TITLE
refactor: Breadcrumbsコンポーネントのインターフェースを要求仕様に合わせて変更

### DIFF
--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -43,9 +43,9 @@ export default async function Services() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           {/* パンくずリスト */}
           <Breadcrumbs
-            items={[
-              { label: 'ホーム', href: '/' },
-              { label: 'サービス総合案内' }
+            segments={[
+              { name: 'ホーム', href: '/' },
+              { name: 'サービス総合案内', href: '/services' }
             ]}
           />
           {/* Sanityからのデータがある場合は動的に表示 */}

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,26 +1,26 @@
 import Link from 'next/link';
 import Script from 'next/script';
 
-interface BreadcrumbItem {
-  label: string;
-  href?: string;
+interface BreadcrumbSegment {
+  name: string;
+  href: string;
 }
 
 interface BreadcrumbsProps {
-  items: BreadcrumbItem[];
+  segments: BreadcrumbSegment[];
   includeJsonLd?: boolean;
 }
 
-export default function Breadcrumbs({ items, includeJsonLd = true }: BreadcrumbsProps) {
+export default function Breadcrumbs({ segments, includeJsonLd = true }: BreadcrumbsProps) {
   // JSON-LD構造化データの生成
   const jsonLd = includeJsonLd ? {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
-    itemListElement: items.map((item, index) => ({
+    itemListElement: segments.map((segment, index) => ({
       '@type': 'ListItem',
       position: index + 1,
-      name: item.label,
-      ...(item.href && { item: `${process.env.NEXT_PUBLIC_SITE_URL || ''}${item.href}` }),
+      name: segment.name,
+      item: `${process.env.NEXT_PUBLIC_SITE_URL || ''}${segment.href}`,
     })),
   } : null;
 
@@ -35,18 +35,18 @@ export default function Breadcrumbs({ items, includeJsonLd = true }: Breadcrumbs
       )}
       <nav aria-label="パンくずリスト" className="text-sm mb-6">
         <ol className="flex flex-wrap items-center">
-          {items.map((item, index) => (
+          {segments.map((segment, index) => (
             <li key={index} className="flex items-center">
               {index > 0 && <span className="mx-2 text-gray-400">{'>'}</span>}
-              {item.href ? (
+              {index < segments.length - 1 ? (
                 <Link
-                  href={item.href}
+                  href={segment.href}
                   className="text-blue-600 hover:text-blue-800 hover:underline"
                 >
-                  {item.label}
+                  {segment.name}
                 </Link>
               ) : (
-                <span className="text-gray-700">{item.label}</span>
+                <span className="text-gray-700">{segment.name}</span>
               )}
             </li>
           ))}


### PR DESCRIPTION
- propsを`items`から`segments`に変更
- フィールド名を`label`から`name`に変更
- `href`を必須プロパティに変更
- 最後の項目も含めて全てのセグメントにhrefを持たせる設計に変更
- services/page.tsxの使用箇所も新しいインターフェースに合わせて更新

🤖 Generated with [Claude Code](https://claude.ai/code)