### PR TITLE
fix: Breadcrumbsコンポーネントの使用箇所で型エラーを修正

### DIFF
--- a/src/app/services/[category]/[slug]/page.tsx
+++ b/src/app/services/[category]/[slug]/page.tsx
@@ -142,11 +142,11 @@ export default async function ServiceDetailPage({ params }: Props) {
       <main className="max-w-6xl mx-auto px-4 py-12 space-y-16">
         {/* パンくず */}
         <Breadcrumbs
-          items={[
-            { label: 'ホーム', href: '/' },
-            { label: 'サービス案内', href: '/services' },
-            { label: data.parentCategory?.title || category, href: `/services/${category}` },
-            { label: data.title },
+          segments={[
+            { name: 'ホーム', href: '/' },
+            { name: 'サービス案内', href: '/services' },
+            { name: data.parentCategory?.title || category, href: `/services/${category}` },
+            { name: data.title, href: `/services/${category}/${slug}` },
           ]}
         />
 

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -84,10 +84,10 @@ export default async function CategoryPage({ params }: Props) {
       <div className="max-w-6xl mx-auto px-4 py-12 space-y-16">
       {/* パンくず */}
       <Breadcrumbs
-        items={[
-          { label: 'ホーム', href: '/' },
-          { label: 'サービス案内', href: '/services' },
-          { label: data.title },
+        segments={[
+          { name: 'ホーム', href: '/' },
+          { name: 'サービス案内', href: '/services' },
+          { name: data.title, href: `/services/${category}` },
         ]}
       />
 


### PR DESCRIPTION
- itemsプロパティをsegmentsプロパティに変更
- labelプロパティをnameプロパティに変更
- 最後のセグメントにもhrefを追加してコンポーネントの期待する型に合わせる

🤖 Generated with [Claude Code](https://claude.ai/code)