### PR TITLE
refactor: FaqAccordionコンポーネントのインターフェースを更新

### DIFF
--- a/src/app/services/[category]/[slug]/page.tsx
+++ b/src/app/services/[category]/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { ServiceDetail } from '@/lib/types';
 import { PortableText } from '@portabletext/react';
 import Header from '@/components/Header';
 import Breadcrumbs from '@/components/Breadcrumbs';
-import FaqAccordion from '@/components/FaqAccordion';
+import { FaqAccordion } from '@/components/FaqAccordion';
 import Script from 'next/script';
 
 type Props = {
@@ -228,7 +228,7 @@ export default async function ServiceDetailPage({ params }: Props) {
             <h2 className="text-2xl font-bold text-[#004080] mb-6">
               よくある質問
             </h2>
-            <FaqAccordion items={data.faq} />
+            <FaqAccordion faqs={data.faq} />
           </section>
         )}
 

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -7,7 +7,7 @@ import { categoryPageQuery, categorySlugsQuery } from '@/lib/queries';
 import { ServiceCategory } from '@/lib/types';
 import { PortableText } from '@portabletext/react';
 import Header from '@/components/Header';
-import FaqAccordion from '@/components/FaqAccordion';
+import { FaqAccordion } from '@/components/FaqAccordion';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import CtaBanner from '@/components/CtaBanner';
 import ServiceTable from '@/components/ServiceTable';
@@ -110,7 +110,7 @@ export default async function CategoryPage({ params }: Props) {
       {data.faq && data.faq.length > 0 && (
         <section>
           <h2 className="text-2xl font-semibold mb-4">よくあるご質問</h2>
-          <FaqAccordion items={data.faq} />
+          <FaqAccordion faqs={data.faq} />
         </section>
       )}
 

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react';
 import { FaqItem } from '@/lib/types';
 
 interface FaqAccordionProps {
-  items: FaqItem[];
+  faqs: FaqItem[];
 }
 
-export default function FaqAccordion({ items }: FaqAccordionProps) {
+export function FaqAccordion({ faqs }: FaqAccordionProps) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const toggleItem = (index: number) => {
@@ -16,13 +16,13 @@ export default function FaqAccordion({ items }: FaqAccordionProps) {
 
   return (
     <div className="space-y-4">
-      {items.map((item, index) => (
+      {faqs.map((faq, index) => (
         <div key={index} className="border border-gray-200 rounded-lg">
           <button
             className="w-full px-6 py-4 text-left flex justify-between items-center hover:bg-gray-50 transition-colors"
             onClick={() => toggleItem(index)}
           >
-            <span className="font-medium text-gray-900">{item.question}</span>
+            <span className="font-medium text-gray-900">{faq.question}</span>
             <svg
               className={`w-5 h-5 text-gray-500 transition-transform ${
                 openIndex === index ? 'rotate-180' : ''
@@ -41,7 +41,7 @@ export default function FaqAccordion({ items }: FaqAccordionProps) {
           </button>
           {openIndex === index && (
             <div className="px-6 py-4 border-t border-gray-200">
-              <p className="text-gray-700">{item.answer}</p>
+              <p className="text-gray-700">{faq.answer}</p>
             </div>
           )}
         </div>


### PR DESCRIPTION
- propsを`items`から`faqs`に変更してより明確に
- デフォルトエクスポートから名前付きエクスポートに変更
- 階層2と階層3の使用箇所を更新

🤖 Generated with [Claude Code](https://claude.ai/code)