### PR TITLE
feat: Sanityスキーマのタグフィールドにtagsレイアウトオプションを追加

### DIFF
--- a/sanity/schemaTypes/serviceDetail.ts
+++ b/sanity/schemaTypes/serviceDetail.ts
@@ -125,6 +125,9 @@ export default {
       type: 'array',
       title: 'タグ（複数可）',
       of: [{ type: 'string' }],
+      options: {
+        layout: 'tags'
+      }
     },
   ],
   orderings: [


### PR DESCRIPTION
- serviceDetailスキーマのtagフィールドにlayout: 'tags'オプションを追加
- Sanity StudioでのUI改善（タグ形式での入力が可能に）

🤖 Generated with [Claude Code](https://claude.ai/code)