### PR TITLE
feat: serviceDetailQueryに関連サービス取得クエリを追加

### DIFF
--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -87,6 +87,14 @@ export const serviceDetailQuery = `
       _id,
       title,
       "slug": slug.current
+    },
+    "related": *[_type == "serviceDetail" && _id != ^._id && count(tag[@ in ^.tag]) > 0][0...4] {
+      title,
+      "slug": slug.current,
+      overview,
+      "parentCategory": parentCategory-> {
+        "slug": slug.current
+      }
     }
   }
 `;


### PR DESCRIPTION
- 同じタグを持つ関連サービスを最大4件取得
- サービス詳細ページで関連サービスを直接取得可能に
- parentCategoryのslugも含めてルーティング用の情報を完備

🤖 Generated with [Claude Code](https://claude.ai/code)