### PR TITLE
feat: 階層3ページの関連サービス表示を新しいUIで実装

### DIFF
--- a/src/app/services/[category]/[slug]/page.tsx
+++ b/src/app/services/[category]/[slug]/page.tsx
@@ -109,8 +109,8 @@ export default async function ServiceDetailPage({ params }: Props) {
     notFound();
   }
 
-  // 関連サービスの取得
-  const relatedServices = await getRelatedServices(data._id, data.tag || []);
+  // 関連サービスの取得（新しいrelated フィールドを優先）
+  const relatedServices = data.related ? [] : await getRelatedServices(data._id, data.tag || []);
 
   // FAQ構造化データの生成
   const faqStructuredData = data.faq && data.faq.length > 0 ? {
@@ -233,7 +233,24 @@ export default async function ServiceDetailPage({ params }: Props) {
         )}
 
         {/* 関連サービス */}
-        {relatedServices.length > 0 && (
+        {data.related && data.related.length > 0 && (
+          <section>
+            <h2 className="text-xl font-bold my-6">関連サービス</h2>
+            <ul className="grid gap-4 md:grid-cols-2">
+              {data.related.map((item) => (
+                <li key={item.slug}>
+                  <Link href={`/services/${item.parentCategory.slug}/${item.slug}`} className="block p-4 border rounded-lg hover:bg-gray-50">
+                    <h3 className="text-lg font-semibold">{item.title}</h3>
+                    <p className="text-sm text-gray-600 mt-2">{item.overview}</p>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        
+        {/* 既存の関連サービス（フォールバック） */}
+        {!data.related && relatedServices.length > 0 && (
           <section aria-label="関連サービス" className="bg-gray-50 rounded-xl p-8">
             <h2 className="text-2xl font-bold text-[#004080] mb-2">
               このようなサービスもご覧になっています

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,4 +82,12 @@ export interface ServiceDetail {
     title: string;
     slug: string;
   };
+  related?: Array<{
+    title: string;
+    slug: string;
+    overview?: string;
+    parentCategory: {
+      slug: string;
+    };
+  }>;
 }


### PR DESCRIPTION
- ServiceDetail型に関連サービスのフィールドを追加
- serviceDetailQueryのrelatedフィールドを使用する新しいUI実装
- 既存の関連サービス表示をフォールバックとして維持
- よりシンプルなグリッドレイアウトでのデザイン

🤖 Generated with [Claude Code](https://claude.ai/code)