### PR TITLE
feat: Sanityスキーマに価格帯フィールドを追加

### DIFF
--- a/sanity/schemaTypes/serviceDetail.ts
+++ b/sanity/schemaTypes/serviceDetail.ts
@@ -58,6 +58,24 @@ export default {
       title: '料金目安',
     },
     {
+      name: 'priceMin',
+      title: '料金（最低）',
+      type: 'number',
+      description: '報酬額の下限値（円）'
+    },
+    {
+      name: 'priceMax',
+      title: '料金（最高）',
+      type: 'number',
+      description: '報酬額の上限値（円）'
+    },
+    {
+      name: 'priceNote',
+      title: '料金備考',
+      type: 'string',
+      description: '実費や特記事項など'
+    },
+    {
       name: 'problemStatement',
       type: 'array',
       title: 'お悩み提起',

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -56,7 +56,10 @@ export const categoryPageQuery = `
       "slug": slug.current,
       overview,
       target,
-      price
+      price,
+      priceMin,
+      priceMax,
+      priceNote
     }
   }
 `;
@@ -70,6 +73,9 @@ export const serviceDetailQuery = `
     overview,
     target,
     price,
+    priceMin,
+    priceMax,
+    priceNote,
     problemStatement,
     serviceMerits,
     serviceFlow,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,9 @@ export interface ServiceDetailLite {
   overview: string;
   target: string;
   price: string;
+  priceMin?: number;
+  priceMax?: number;
+  priceNote?: string;
 }
 
 // Sanity Image Asset型定義
@@ -66,6 +69,9 @@ export interface ServiceDetail {
   overview?: string;
   target?: string;
   price?: string;
+  priceMin?: number;
+  priceMax?: number;
+  priceNote?: string;
   problemStatement?: PortableTextBlock[];
   serviceMerits?: PortableTextBlock[];
   serviceFlow?: PortableTextBlock[];


### PR DESCRIPTION
- priceMin: 料金の下限値（円）
- priceMax: 料金の上限値（円）
- priceNote: 料金備考（実費や特記事項など）
- ServiceDetailとServiceDetailLite型定義を更新
- GROQクエリで新しいフィールドを取得

🤖 Generated with [Claude Code](https://claude.ai/code)