### PR TITLE
feat: ServiceTableコンポーネントに価格帯表示ロジックを実装

### DIFF
--- a/src/components/ServiceTable.tsx
+++ b/src/components/ServiceTable.tsx
@@ -39,7 +39,11 @@ export default function ServiceTable({ services, categorySlug }: ServiceTablePro
                   {service.target}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  {service.price}
+                  {service.priceMin && service.priceMax
+                    ? `¥${service.priceMin.toLocaleString()}〜¥${service.priceMax.toLocaleString()}`
+                    : service.priceMin
+                    ? `¥${service.priceMin.toLocaleString()}〜`
+                    : service.priceNote ?? '個別見積り'}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                   <Link


### PR DESCRIPTION
- priceMinとpriceMaxが両方ある場合: ¥10,000〜¥50,000
- priceMinのみの場合: ¥10,000〜
- どちらもない場合: priceNoteまたは「個別見積り」
- toLocaleString()で価格を3桁区切り表示

🤖 Generated with [Claude Code](https://claude.ai/code)