### PR TITLE
feat: SanityスキーマのSEOフィールドに説明文を追加

### DIFF
--- a/sanity/schemaTypes/serviceCategory.ts
+++ b/sanity/schemaTypes/serviceCategory.ts
@@ -78,16 +78,19 @@ export default {
       name: 'metaTitle',
       type: 'string',
       title: 'SEOタイトル',
+      description: '検索エンジンやブラウザタブに表示されるタイトル'
     },
     {
       name: 'metaDescription',
       type: 'text',
       title: 'SEOディスクリプション',
+      description: '検索結果に表示されるページの説明文（120〜160字推奨）'
     },
     {
       name: 'ogImage',
       type: 'image',
       title: 'OGP画像',
+      description: 'SNSなどでシェアされた時に表示される画像'
     },
   ],
   orderings: [

--- a/sanity/schemaTypes/serviceDetail.ts
+++ b/sanity/schemaTypes/serviceDetail.ts
@@ -127,16 +127,19 @@ export default {
       name: 'metaTitle',
       type: 'string',
       title: 'SEOタイトル',
+      description: '検索エンジンやブラウザタブに表示されるタイトル'
     },
     {
       name: 'metaDescription',
       type: 'text',
       title: 'SEOディスクリプション',
+      description: '検索結果に表示されるページの説明文（120〜160字推奨）'
     },
     {
       name: 'ogImage',
       type: 'image',
       title: 'OGP画像',
+      description: 'SNSなどでシェアされた時に表示される画像'
     },
     {
       name: 'tag',


### PR DESCRIPTION
- metaTitle: 検索エンジンやブラウザタブに表示されるタイトル
- metaDescription: 検索結果に表示されるページの説明文（120〜160字推奨）
- ogImage: SNSなどでシェアされた時に表示される画像

serviceCategoryとserviceDetailの両スキーマに追加

🤖 Generated with [Claude Code](https://claude.ai/code)