### PR TITLE
feat: GROQクエリと型定義にorderRankフィールドを追加

### DIFF
--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -59,7 +59,8 @@ export const categoryPageQuery = `
       price,
       priceMin,
       priceMax,
-      priceNote
+      priceNote,
+      orderRank
     }
   }
 `;
@@ -76,6 +77,7 @@ export const serviceDetailQuery = `
     priceMin,
     priceMax,
     priceNote,
+    orderRank,
     problemStatement,
     serviceMerits,
     serviceFlow,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,7 @@ export interface ServiceDetailLite {
   priceMin?: number;
   priceMax?: number;
   priceNote?: string;
+  orderRank?: number;
 }
 
 // Sanity Image Asset型定義
@@ -72,6 +73,7 @@ export interface ServiceDetail {
   priceMin?: number;
   priceMax?: number;
   priceNote?: string;
+  orderRank?: number;
   problemStatement?: PortableTextBlock[];
   serviceMerits?: PortableTextBlock[];
   serviceFlow?: PortableTextBlock[];


### PR DESCRIPTION
- categoryPageQueryのservicesサブクエリにorderRankを追加
- serviceDetailQueryにorderRankを追加
- ServiceDetailLiteとServiceDetail型定義にorderRankを追加

デバッグやソート確認のためにorderRankの値を取得可能に

🤖 Generated with [Claude Code](https://claude.ai/code)