### PR TITLE
feat: 階層3ページに関連サービス表示機能を実装

### DIFF
--- a/src/components/RelatedServices.tsx
+++ b/src/components/RelatedServices.tsx
@@ -5,11 +5,11 @@ import Link from 'next/link';
 type RelatedService = {
   _id: string;
   title: string;
-  slug: { current: string };
+  slug: string;
   overview: string;
   target: string;
   price: string;
-  tag: string[];
+  tag?: string[];
 };
 
 type Props = {
@@ -27,7 +27,7 @@ export default function RelatedServices({ services, currentCategorySlug }: Props
         {services.map((service) => (
           <Link
             key={service._id}
-            href={`/services/${currentCategorySlug}/${service.slug.current}`}
+            href={`/services/${currentCategorySlug}/${service.slug}`}
             className="block border border-gray-200 p-4 rounded-lg hover:shadow-md transition"
           >
             <h3 className="text-lg font-semibold">{service.title}</h3>

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -97,6 +97,7 @@ export const serviceDetailQuery = `
       title,
       "slug": slug.current
     },
+    "parentCategoryRef": parentCategory._ref,
     "related": *[_type == "serviceDetail" && _id != ^._id && count(tag[@ in ^.tag]) > 0][0...4] {
       title,
       "slug": slug.current,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,6 +91,7 @@ export interface ServiceDetail {
     title: string;
     slug: string;
   };
+  parentCategoryRef?: string;
   related?: Array<{
     title: string;
     slug: string;


### PR DESCRIPTION
- serviceDetailQueryにparentCategoryRefを追加
- ServiceDetail型にparentCategoryRefを追加
- relatedServicesQueryを使用した関連サービス取得処理を実装
- RelatedServicesコンポーネントをページに統合
- 同じカテゴリ内でタグが共通するサービスを表示

🤖 Generated with Claude Code