### PR TITLE
feat: 階層3ページにService構造化データ（JSON-LD）を追加

### DIFF
--- a/src/app/services/[category]/[slug]/page.tsx
+++ b/src/app/services/[category]/[slug]/page.tsx
@@ -137,18 +137,52 @@ export default async function ServiceDetailPage({ params }: Props) {
     })),
   } : null;
 
+  // Service構造化データの生成
+  const serviceStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: data.title,
+    description: data.overview || data.metaDescription || '',
+    provider: {
+      '@type': 'LegalService',
+      name: 'フォルティア行政書士事務所',
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: '茂原579',
+        addressLocality: '茂原市',
+        addressRegion: '千葉県',
+        postalCode: '297-0026',
+        addressCountry: 'JP'
+      }
+    },
+    ...(data.priceMin || data.priceMax || data.price ? {
+      offers: {
+        '@type': 'Offer',
+        price: data.priceMin || data.price || '',
+        priceCurrency: 'JPY',
+        ...(data.priceMin && data.priceMax ? {
+          priceRange: `¥${data.priceMin.toLocaleString()}〜¥${data.priceMax.toLocaleString()}`
+        } : {})
+      }
+    } : {}),
+    areaServed: ['東京都', '千葉県', '埼玉県', '神奈川県']
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
 
-      {/* FAQ構造化データ */}
-      {faqStructuredData && (
-        <Script
-          id="faq-structured-data"
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqStructuredData) }}
-        />
-      )}
+      {/* 構造化データ */}
+      <Script
+        id="structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ 
+          __html: JSON.stringify([
+            ...(faqStructuredData ? [faqStructuredData] : []),
+            serviceStructuredData
+          ])
+        }}
+      />
 
       <main className="max-w-6xl mx-auto px-4 py-12 space-y-16">
         {/* パンくず */}


### PR DESCRIPTION
- 既存のFAQ構造化データに加えてService構造化データを実装
- LegalServiceプロバイダー情報（フォルティア行政書士事務所）を含む
- 料金情報（priceMin/priceMax/price）を動的に構造化
- 対応エリア情報を追加
- FAQとServiceの構造化データを配列形式で出力

🤖 Generated with Claude Code