### PR TITLE
feat: PageHeaderコンポーネントを作成し、各ページに適用

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import Header from "@/components/Header";
+import PageHeader from "@/components/PageHeader";
 import { useState } from "react";
 
 export default function About() {
@@ -55,13 +56,10 @@ export default function About() {
     <div className="min-h-screen bg-gray-50">
       <Header />
 
-      {/* Page Header */}
-      <section className="bg-blue-600 text-white py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-4xl font-bold mb-4">事務所概要</h1>
-          <p className="text-xl">フォルティア行政書士事務所について</p>
-        </div>
-      </section>
+      <PageHeader 
+        title="事務所概要"
+        description="フォルティア行政書士事務所について"
+      />
 
       {/* About Content */}
       <section className="py-16">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Header from "@/components/Header";
+import PageHeader from "@/components/PageHeader";
 // import { getBlogs } from "../../../lib/sanity";
 
 // ブログ記事の型定義
@@ -82,6 +83,11 @@ export default async function BlogPage() {
     <div className="min-h-screen bg-gray-50">
       <Header />
 
+      <PageHeader 
+        title="お役立ち情報"
+        description="行政書士業務に関する有用な情報や法改正のポイントなど、皆様のお役に立つ情報をお届けします"
+      />
+
       {/* Breadcrumb */}
       <nav className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
@@ -94,18 +100,6 @@ export default async function BlogPage() {
           </div>
         </div>
       </nav>
-
-      {/* Page Header */}
-      <div className="bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="text-center">
-            <h1 className="text-3xl font-bold text-gray-900 mb-4">お役立ち情報</h1>
-            <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-              行政書士業務に関する有用な情報や法改正のポイントなど、皆様のお役に立つ情報をお届けします。
-            </p>
-          </div>
-        </div>
-      </div>
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Header from "@/components/Header";
+import PageHeader from "@/components/PageHeader";
 // import { getNews } from "../../../lib/sanity";
 
 // ニュースの型定義
@@ -31,14 +32,13 @@ export default async function NewsPage() {
     <div className="min-h-screen bg-gray-50">
       <Header />
 
+      <PageHeader 
+        title="お知らせ"
+        description="フォルティア行政書士事務所からの最新情報をお届けします"
+      />
+
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-4">お知らせ</h1>
-          <p className="text-lg text-gray-600">
-            フォルティア行政書士事務所からの最新情報をお届けします。
-          </p>
-        </div>
 
         {/* News List */}
         <div className="grid gap-6">

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Header from "@/components/Header";
 import Breadcrumbs from "@/components/Breadcrumbs";
+import PageHeader from "@/components/PageHeader";
 import { sanityClient } from '@/lib/sanity.client';
 import { allServiceCategoriesQuery } from '@/lib/queries';
 import { ServiceCategory } from '@/lib/types';
@@ -30,13 +31,10 @@ export default async function Services() {
     <div className="min-h-screen bg-gray-50">
       <Header />
 
-      {/* Page Header */}
-      <section className="bg-[#004080] text-white py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-4xl font-bold mb-4">サービス総合案内</h1>
-          <p className="text-xl">お客様のニーズに合わせた幅広いサービスを提供しています</p>
-        </div>
-      </section>
+      <PageHeader 
+        title="サービス総合案内"
+        description="お客様のニーズに合わせた幅広いサービスを提供しています"
+      />
 
       {/* Services Content */}
       <section className="py-16">

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Header from "@/components/Header";
+import PageHeader from "@/components/PageHeader";
 // import { getTestimonials } from "../../../lib/sanity";
 
 // お客様の声の型定義
@@ -74,6 +75,11 @@ export default async function TestimonialsPage() {
     <div className="min-h-screen bg-gray-50">
       <Header />
 
+      <PageHeader 
+        title="お客様の声"
+        description="当事務所をご利用いただいたお客様からの貴重なご意見・ご感想をご紹介いたします"
+      />
+
       {/* Breadcrumb */}
       <nav className="bg-white border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
@@ -86,18 +92,6 @@ export default async function TestimonialsPage() {
           </div>
         </div>
       </nav>
-
-      {/* Page Header */}
-      <div className="bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="text-center">
-            <h1 className="text-3xl font-bold text-gray-900 mb-4">お客様の声</h1>
-            <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-              当事務所をご利用いただいたお客様からの貴重なご意見・ご感想をご紹介いたします。
-            </p>
-          </div>
-        </div>
-      </div>
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,15 @@
+interface PageHeaderProps {
+  title: string;
+  description: string;
+}
+
+export default function PageHeader({ title, description }: PageHeaderProps) {
+  return (
+    <section className="bg-[#004080] text-white py-16">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 className="text-4xl font-bold mb-4">{title}</h1>
+        <p className="text-xl">{description}</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
- サービスページの青帯デザインをPageHeaderコンポーネントとして共通化
- 背景色: #004080、白色テキスト、py-16のパディング
- 以下のページに適用:
  - サービス総合案内
  - 事務所概要
  - お知らせ
  - お役立ち情報（ブログ）
  - お客様の声

🤖 Generated with Claude Code