### PR TITLE
feat: サービス関連ページにパンくずリスト（Breadcrumb）を実装

### DIFF
--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -8,48 +8,53 @@ interface BreadcrumbSegment {
 
 interface BreadcrumbsProps {
   segments: BreadcrumbSegment[];
-  includeJsonLd?: boolean;
 }
 
-export default function Breadcrumbs({ segments, includeJsonLd = true }: BreadcrumbsProps) {
-  // JSON-LD構造化データの生成
-  const jsonLd = includeJsonLd ? {
+export default function Breadcrumbs({ segments }: BreadcrumbsProps) {
+  // SEO構造化データの生成
+  const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: segments.map((segment, index) => ({
       '@type': 'ListItem',
       position: index + 1,
       name: segment.name,
-      item: `${process.env.NEXT_PUBLIC_SITE_URL || ''}${segment.href}`,
+      item: `${process.env.NEXT_PUBLIC_BASE_URL || ''}${segment.href}`,
     })),
-  } : null;
+  };
 
   return (
     <>
-      {jsonLd && (
-        <Script
-          id="breadcrumb-jsonld"
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
-      )}
-      <nav aria-label="パンくずリスト" className="text-sm mb-6">
-        <ol className="flex flex-wrap items-center">
-          {segments.map((segment, index) => (
-            <li key={index} className="flex items-center">
-              {index > 0 && <span className="mx-2 text-gray-400">{'>'}</span>}
-              {index < segments.length - 1 ? (
-                <Link
-                  href={segment.href}
-                  className="text-blue-600 hover:text-blue-800 hover:underline"
-                >
-                  {segment.name}
-                </Link>
-              ) : (
-                <span className="text-gray-700">{segment.name}</span>
-              )}
-            </li>
-          ))}
+      {/* 構造化データ */}
+      <Script
+        id="breadcrumb-structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      
+      {/* パンくずリストUI */}
+      <nav aria-label="パンくずリスト" className="mb-8">
+        <ol className="flex flex-wrap items-center gap-2 text-sm">
+          {segments.map((segment, index) => {
+            const isLast = index === segments.length - 1;
+            return (
+              <li key={segment.href} className="flex items-center">
+                {isLast ? (
+                  <span className="text-gray-900 font-medium">{segment.name}</span>
+                ) : (
+                  <>
+                    <Link 
+                      href={segment.href}
+                      className="text-gray-600 hover:text-gray-900 transition-colors"
+                    >
+                      {segment.name}
+                    </Link>
+                    <span className="mx-2 text-gray-400">＞</span>
+                  </>
+                )}
+              </li>
+            );
+          })}
         </ol>
       </nav>
     </>


### PR DESCRIPTION
- Breadcrumbsコンポーネントを作成（SEO構造化データ付き）
- サービス総合案内ページ（階層1）に実装
- カテゴリーページ（階層2）に実装
- サービス詳細ページ（階層3）に実装
- JSON-LD形式の構造化データでSEOを強化

🤖 Generated with [Claude Code](https://claude.ai/code)