### PR TITLE
feat: サービス関連ページに共通CTAバナーを実装

### DIFF
--- a/src/app/services/[category]/[slug]/page.tsx
+++ b/src/app/services/[category]/[slug]/page.tsx
@@ -14,6 +14,7 @@ import Header from '@/components/Header';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import { FaqAccordion } from '@/components/FaqAccordion';
 import RelatedServices from '@/components/RelatedServices';
+import CtaBanner from '@/components/CtaBanner';
 import Script from 'next/script';
 
 type Props = {
@@ -381,22 +382,7 @@ export default async function ServiceDetailPage({ params }: Props) {
         )}
 
         {/* CTA */}
-        <section aria-label="お問い合わせ" className="mx-auto mt-12 text-center">
-          <div className="bg-[#004080] text-white rounded-xl p-8 max-w-2xl mx-auto">
-            <h2 className="text-2xl font-bold mb-4">
-              {data.title}について相談する
-            </h2>
-            <p className="mb-6">
-              お気軽にお問い合わせください。初回相談は無料です。
-            </p>
-            <Link
-              href={`/contact?service=${slug}`}
-              className="inline-block bg-white text-[#004080] px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors"
-            >
-              無料相談を申し込む
-            </Link>
-          </div>
-        </section>
+        <CtaBanner serviceTitle={data.title} />
       </main>
 
       {/* Footer */}

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -125,10 +125,7 @@ export default async function CategoryPage({ params }: Props) {
       </div>
 
       {/* CTA */}
-      <CtaBanner
-        text={`${data.title}について無料で相談する`}
-        href={`/contact?service=${data.slug}`}
-      />
+      <CtaBanner categoryTitle={data.title} />
       </div>
 
       {/* Footer */}

--- a/src/components/CtaBanner.tsx
+++ b/src/components/CtaBanner.tsx
@@ -1,21 +1,53 @@
 import Link from 'next/link';
 
 interface CtaBannerProps {
-  text: string;
-  href: string;
+  text?: string;
+  href?: string;
   buttonText?: string;
+  categoryTitle?: string;
+  serviceTitle?: string;
 }
 
-export default function CtaBanner({ text, href, buttonText = 'お問い合わせ' }: CtaBannerProps) {
+export default function CtaBanner({ 
+  text, 
+  href, 
+  buttonText,
+  categoryTitle, 
+  serviceTitle 
+}: CtaBannerProps) {
+  // 自動生成されるテキストとhref
+  const generatedText = serviceTitle 
+    ? `${serviceTitle}について相談する`
+    : categoryTitle 
+    ? `${categoryTitle}について無料で相談する`
+    : '無料相談のお申込み';
+
+  const queryParam = serviceTitle || categoryTitle;
+  const generatedHref = queryParam 
+    ? `/contact?service=${encodeURIComponent(queryParam)}`
+    : '/contact';
+
+  // 実際に使用する値（propsが優先）
+  const finalText = text || generatedText;
+  const finalHref = href || generatedHref;
+  const finalButtonText = buttonText || '無料相談を申し込む';
+
   return (
-    <div className="bg-blue-600 text-white rounded-xl p-8 text-center">
-      <h3 className="text-2xl font-bold mb-4">{text}</h3>
-      <Link
-        href={href}
-        className="inline-block bg-white text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors"
-      >
-        {buttonText}
-      </Link>
-    </div>
+    <section className="bg-[#004080] py-12">
+      <div className="max-w-4xl mx-auto px-4 text-center">
+        <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
+          {finalText}
+        </h2>
+        <p className="text-white mb-8 text-lg">
+          お気軽にお問い合わせください。初回相談は無料です。
+        </p>
+        <Link
+          href={finalHref}
+          className="inline-block bg-white text-[#004080] font-bold text-lg px-8 py-4 rounded-lg hover:bg-gray-100 transition-colors w-full sm:w-auto"
+        >
+          {finalButtonText}
+        </Link>
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
- CtaBannerコンポーネントを拡張（categoryTitle/serviceTitleプロパティ追加）
- カテゴリーページと詳細ページで動的にテキストを生成
- お問い合わせページへのクエリパラメータを自動設定
- レスポンシブデザイン対応（モバイルでフル幅表示）

🤖 Generated with [Claude Code](https://claude.ai/code)