### PR TITLE
feat: サービスアイコンのデザインを改善

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -201,18 +201,18 @@ export default async function Home() {
                   href={`/services/${category.slug}`}
                   className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center block"
                 >
-                  <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4 relative overflow-hidden">
+                  <div className="mb-4">
                     {category.iconUrl ? (
                       <Image
                         src={category.iconUrl}
                         alt={category.title}
-                        width={24}
-                        height={24}
-                        className="object-contain"
+                        width={48}
+                        height={48}
+                        className="object-contain mx-auto"
                         unoptimized
                       />
                     ) : (
-                      <svg className="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-12 h-12 text-gray-600 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                       </svg>
                     )}
@@ -227,13 +227,13 @@ export default async function Home() {
             
             {/* 外国人関連業務 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-foreigner.png"
                   alt="外国人関連業務"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                   priority
                 />
@@ -243,13 +243,13 @@ export default async function Home() {
 
             {/* 建設・宅建業関連 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-construction.png"
                   alt="建設・宅建業関連"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -258,13 +258,13 @@ export default async function Home() {
 
             {/* 自動車関連業務 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-vehicle.png"
                   alt="自動車関連業務"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -273,13 +273,13 @@ export default async function Home() {
 
             {/* 飲食・風俗営業 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-restaurant.png"
                   alt="飲食・風俗営業"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -288,13 +288,13 @@ export default async function Home() {
 
             {/* 廃棄物処理業許可 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-waste.png"
                   alt="廃棄物処理業許可"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -303,13 +303,13 @@ export default async function Home() {
 
             {/* 旅行・旅館業 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-travel.png"
                   alt="旅行・旅館業"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -318,13 +318,13 @@ export default async function Home() {
 
             {/* 法人設立業務 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-corporation.png"
                   alt="法人設立業務"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -333,13 +333,13 @@ export default async function Home() {
 
             {/* 営業許可 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-license.png"
                   alt="営業許可"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -348,13 +348,13 @@ export default async function Home() {
 
             {/* 土地関連業務 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-land.png"
                   alt="土地関連業務"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -363,13 +363,13 @@ export default async function Home() {
 
             {/* 権利義務・事実証明 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-document.png"
                   alt="権利義務・事実証明"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>
@@ -378,13 +378,13 @@ export default async function Home() {
 
             {/* その他の業務 */}
             <div className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="mb-4">
                 <Image
                   src="/service-other.png"
                   alt="その他の業務"
-                  width={24}
-                  height={24}
-                  className="object-contain"
+                  width={48}
+                  height={48}
+                  className="object-contain mx-auto"
                   unoptimized
                 />
               </div>


### PR DESCRIPTION
- 灰色の丸い背景（bg-gray-100 rounded-full）を削除
- アイコンサイズを24x24から48x48に拡大
- mx-autoクラスで中央配置を維持
- SVGアイコンも同様にサイズを拡大（w-6 h-6 → w-12 h-12）

これによりアイコンがより目立つようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)