### PR TITLE
feat: 主要サービスセクションのUI導線を改善

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -196,9 +196,17 @@ export default async function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">主要サービス</h2>
-            <p className="text-lg text-gray-600">
+            <p className="text-lg text-gray-600 mb-8">
               豊富な経験と専門知識で、お客様のニーズにお応えします
             </p>
+            
+            {/* ステップガイド */}
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 max-w-2xl mx-auto mb-8">
+              <div className="flex items-center justify-center space-x-2">
+                <div className="bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">1</div>
+                <p className="text-blue-800 font-medium">まずは、お困りの内容に該当するサービスをクリックしてください</p>
+              </div>
+            </div>
           </div>
           
           {/* Sanityからのデータがある場合は動的に表示 */}
@@ -208,7 +216,7 @@ export default async function Home() {
                 <Link
                   key={category._id}
                   href={`/services/${category.slug}`}
-                  className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center block"
+                  className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center block group"
                 >
                   <div className="mb-4">
                     {category.iconUrl ? (
@@ -226,7 +234,13 @@ export default async function Home() {
                       </svg>
                     )}
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900">{category.title}</h3>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">{category.title}</h3>
+                  <p className="text-sm text-blue-600 group-hover:text-blue-700 flex items-center justify-center">
+                    詳しく見る
+                    <svg className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </p>
                 </Link>
               ))}
             </div>
@@ -401,6 +415,19 @@ export default async function Home() {
             </div>
           </div>
           )}
+          
+          {/* すべてのサービスを見るボタン */}
+          <div className="text-center mt-12">
+            <Link 
+              href="/services" 
+              className="inline-flex items-center px-6 py-3 bg-gray-900 text-white font-medium rounded-lg hover:bg-gray-800 transition-colors"
+            >
+              すべてのサービスを見る
+              <svg className="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
+            </Link>
+          </div>
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -216,30 +216,42 @@ export default async function Home() {
                 <Link
                   key={category._id}
                   href={`/services/${category.slug}`}
-                  className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md hover:scale-105 transition-all duration-300 text-center block group"
+                  className="bg-white rounded-lg shadow-sm hover:shadow-lg transition-all duration-300 text-center block group relative overflow-hidden"
                 >
-                  <div className="mb-4">
+                  {/* ホバー時のオーバーレイ */}
+                  <div className="absolute inset-0 bg-blue-600 bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-300"></div>
+                  
+                  {/* アイコン部分 */}
+                  <div className="p-6 pb-0">
                     {category.iconUrl ? (
                       <Image
                         src={category.iconUrl}
                         alt={category.title}
                         width={108}
                         height={108}
-                        className="object-contain mx-auto"
+                        className="object-contain mx-auto group-hover:scale-110 transition-transform duration-300"
                         unoptimized
                       />
                     ) : (
-                      <svg className="w-[108px] h-[108px] text-gray-600 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-[108px] h-[108px] text-gray-600 mx-auto group-hover:scale-110 transition-transform duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                       </svg>
                     )}
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900 flex items-center justify-center">
-                    {category.title}
-                    <svg className="w-5 h-5 ml-2 text-gray-400 opacity-0 group-hover:opacity-100 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </h3>
+                  
+                  {/* タイトル部分 */}
+                  <div className="p-4 pt-2">
+                    <h3 className="text-lg font-semibold text-gray-900">{category.title}</h3>
+                  </div>
+                  
+                  {/* ホバー時に表示される矢印 */}
+                  <div className="absolute bottom-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                    <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center">
+                      <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </div>
+                  </div>
                 </Link>
               ))}
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -234,13 +234,12 @@ export default async function Home() {
                       </svg>
                     )}
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-2">{category.title}</h3>
-                  <p className="text-sm text-blue-600 group-hover:text-blue-700 flex items-center justify-center">
-                    詳しく見る
-                    <svg className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <h3 className="text-lg font-semibold text-gray-900 flex items-center justify-center">
+                    {category.title}
+                    <svg className="w-5 h-5 ml-2 text-gray-400 opacity-0 group-hover:opacity-100 group-hover:translate-x-1 transition-all duration-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                     </svg>
-                  </p>
+                  </h3>
                 </Link>
               ))}
             </div>


### PR DESCRIPTION
- ステップガイドを追加（まずはサービスをクリック）
- 各カードに「詳しく見る」リンクを追加
- ホバー時に矢印が動くアニメーション
- 「すべてのサービスを見る」ボタンを追加
- groupクラスでホバー時の統一感を向上