### PR TITLE
feat: 主要サービスセクションにステップガイドを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -199,6 +199,14 @@ export default async function Home() {
             <p className="text-lg text-gray-600">
               豊富な経験と専門知識で、お客様のニーズにお応えします
             </p>
+            <div className="mt-8 bg-blue-50 rounded-lg p-4 inline-block">
+              <p className="text-gray-700 flex items-center">
+                <svg className="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                まずは、お困りの内容に該当するサービスをクリックしてください
+              </p>
+            </div>
           </div>
           
           {/* Sanityからのデータがある場合は動的に表示 */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -409,6 +409,19 @@ export default async function Home() {
             </div>
           </div>
           )}
+
+          {/* すべてのサービスを見るボタン */}
+          <div className="text-center mt-12">
+            <Link 
+              href="/services" 
+              className="inline-flex items-center px-6 py-3 bg-gray-900 text-white font-medium rounded-lg hover:bg-gray-800 transition-colors"
+            >
+              すべてのサービスを見る
+              <svg className="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
+            </Link>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
- 「まずは、お困りの内容に該当するサービスをクリックしてください」という案内を追加
- 青色の背景とアイコンで視覚的にわかりやすく表示