### PR TITLE
refactor: お問い合わせページのヘッダーをPageHeaderコンポーネントに統一

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,18 +1,16 @@
 import Link from "next/link";
 import Header from "@/components/Header";
+import PageHeader from "@/components/PageHeader";
 
 export default function Contact() {
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
 
-      {/* Page Header */}
-      <section className="bg-blue-600 text-white py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-4xl font-bold mb-4">お問い合わせ</h1>
-          <p className="text-xl">お気軽にご相談ください</p>
-        </div>
-      </section>
+      <PageHeader
+        title="お問い合わせ"
+        description="お気軽にご相談ください"
+      />
 
       {/* Contact Content */}
       <section className="py-16">


### PR DESCRIPTION
- 独自の青い背景のヘッダーからPageHeaderコンポーネントを使用するように変更
- 他のページ（事務所概要、サービス、お知らせ等）と同じデザインに統一
- 背景色をbg-blue-600からbg-[#004080]に変更