### PR TITLE
feat: 問い合わせフォームとSanityの連携を実装

### DIFF
--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -3,5 +3,6 @@ import testimonials from './testimonials'
 import blog from './blog'
 import serviceCategory from './serviceCategory'
 import serviceDetail from './serviceDetail'
+import contact from '../schemas/contact'
 
-export const schemaTypes = [news, testimonials, blog, serviceCategory, serviceDetail]
+export const schemaTypes = [news, testimonials, blog, serviceCategory, serviceDetail, contact]

--- a/sanity/schemas/contact.ts
+++ b/sanity/schemas/contact.ts
@@ -77,7 +77,7 @@ export default defineType({
     },
     prepare(selection) {
       const { title, subtitle, date } = selection
-      const serviceLabels = {
+      const serviceLabels: Record<string, string> = {
         permit: '許認可申請',
         inheritance: '相続手続き',
         company: '会社設立',

--- a/sanity/schemas/contact.ts
+++ b/sanity/schemas/contact.ts
@@ -1,0 +1,93 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'contact',
+  title: '問い合わせ',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'お名前',
+      type: 'string',
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: 'email',
+      title: 'メールアドレス',
+      type: 'string',
+      validation: Rule => Rule.required().email()
+    }),
+    defineField({
+      name: 'phone',
+      title: '電話番号',
+      type: 'string'
+    }),
+    defineField({
+      name: 'service',
+      title: 'ご相談内容',
+      type: 'string',
+      options: {
+        list: [
+          { title: '許認可申請', value: 'permit' },
+          { title: '相続手続き', value: 'inheritance' },
+          { title: '会社設立', value: 'company' },
+          { title: '契約書作成', value: 'contract' },
+          { title: 'その他', value: 'other' }
+        ]
+      }
+    }),
+    defineField({
+      name: 'message',
+      title: 'メッセージ',
+      type: 'text',
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: 'status',
+      title: '対応状況',
+      type: 'string',
+      options: {
+        list: [
+          { title: '未対応', value: 'pending' },
+          { title: '対応中', value: 'in_progress' },
+          { title: '完了', value: 'completed' }
+        ],
+        layout: 'radio'
+      },
+      initialValue: 'pending'
+    }),
+    defineField({
+      name: 'notes',
+      title: '対応メモ',
+      type: 'text',
+      description: '内部管理用のメモ'
+    }),
+    defineField({
+      name: 'receivedAt',
+      title: '受信日時',
+      type: 'datetime',
+      validation: Rule => Rule.required()
+    })
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'service',
+      date: 'receivedAt'
+    },
+    prepare(selection) {
+      const { title, subtitle, date } = selection
+      const serviceLabels = {
+        permit: '許認可申請',
+        inheritance: '相続手続き',
+        company: '会社設立',
+        contract: '契約書作成',
+        other: 'その他'
+      }
+      return {
+        title: title,
+        subtitle: `${serviceLabels[subtitle] || subtitle} - ${new Date(date).toLocaleDateString('ja-JP')}`
+      }
+    }
+  }
+})

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { client } from '@/lib/sanity.client';
+import { sanityClient } from '@/lib/sanity.client';
 
 export async function POST(request: NextRequest) {
   try {
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Sanityに保存
-    const contact = await client.create({
+    const contact = await sanityClient.create({
       _type: 'contact',
       name: body.name,
       email: body.email,

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { client } from '@/lib/sanity.client';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    // バリデーション
+    const requiredFields = ['name', 'email', 'message'];
+    for (const field of requiredFields) {
+      if (!body[field]) {
+        return NextResponse.json(
+          { error: `${field}は必須項目です` },
+          { status: 400 }
+        );
+      }
+    }
+
+    // メールアドレスの簡易バリデーション
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(body.email)) {
+      return NextResponse.json(
+        { error: '有効なメールアドレスを入力してください' },
+        { status: 400 }
+      );
+    }
+
+    // Sanityに保存
+    const contact = await client.create({
+      _type: 'contact',
+      name: body.name,
+      email: body.email,
+      phone: body.phone || '',
+      service: body.service || '',
+      message: body.message,
+      status: 'pending',
+      receivedAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'お問い合わせを受け付けました。担当者より折り返しご連絡いたします。',
+      id: contact._id,
+    });
+  } catch (error) {
+    console.error('問い合わせ送信エラー:', error);
+    return NextResponse.json(
+      { error: '送信中にエラーが発生しました。時間をおいて再度お試しください。' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -79,7 +79,7 @@ export default function Contact() {
           message: data.error || '送信に失敗しました。',
         });
       }
-    } catch (error) {
+    } catch {
       setSubmitStatus({
         type: 'error',
         message: 'ネットワークエラーが発生しました。',

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,7 +1,93 @@
+"use client";
+
+import { useState } from "react";
 import Link from "next/link";
 import Header from "@/components/Header";
 
+type FormData = {
+  name: string;
+  email: string;
+  phone: string;
+  service: string;
+  message: string;
+  privacy: boolean;
+};
+
 export default function Contact() {
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    email: '',
+    phone: '',
+    service: '',
+    message: '',
+    privacy: false,
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState<{
+    type: 'success' | 'error' | null;
+    message: string;
+  }>({ type: null, message: '' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value, type } = e.target;
+    if (type === 'checkbox') {
+      setFormData(prev => ({
+        ...prev,
+        [name]: (e.target as HTMLInputElement).checked,
+      }));
+    } else {
+      setFormData(prev => ({
+        ...prev,
+        [name]: value,
+      }));
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setSubmitStatus({ type: null, message: '' });
+
+    try {
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setSubmitStatus({
+          type: 'success',
+          message: data.message || 'お問い合わせを受け付けました。',
+        });
+        // フォームをリセット
+        setFormData({
+          name: '',
+          email: '',
+          phone: '',
+          service: '',
+          message: '',
+          privacy: false,
+        });
+      } else {
+        setSubmitStatus({
+          type: 'error',
+          message: data.error || '送信に失敗しました。',
+        });
+      }
+    } catch (error) {
+      setSubmitStatus({
+        type: 'error',
+        message: 'ネットワークエラーが発生しました。',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
@@ -23,7 +109,18 @@ export default function Contact() {
             <div>
               <h2 className="text-3xl font-bold text-gray-900 mb-6">お問い合わせフォーム</h2>
               <div className="bg-white p-8 rounded-lg shadow-sm">
-                <form className="space-y-6">
+                {submitStatus.type && (
+                  <div
+                    className={`mb-6 p-4 rounded-lg ${
+                      submitStatus.type === 'success'
+                        ? 'bg-green-50 text-green-800 border border-green-200'
+                        : 'bg-red-50 text-red-800 border border-red-200'
+                    }`}
+                  >
+                    {submitStatus.message}
+                  </div>
+                )}
+                <form onSubmit={handleSubmit} className="space-y-6">
                   <div>
                     <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
                       お名前 <span className="text-red-500">*</span>
@@ -32,6 +129,8 @@ export default function Contact() {
                       type="text"
                       id="name"
                       name="name"
+                      value={formData.name}
+                      onChange={handleChange}
                       required
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
@@ -45,6 +144,8 @@ export default function Contact() {
                       type="email"
                       id="email"
                       name="email"
+                      value={formData.email}
+                      onChange={handleChange}
                       required
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
@@ -58,6 +159,8 @@ export default function Contact() {
                       type="tel"
                       id="phone"
                       name="phone"
+                      value={formData.phone}
+                      onChange={handleChange}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
                   </div>
@@ -69,6 +172,8 @@ export default function Contact() {
                     <select
                       id="service"
                       name="service"
+                      value={formData.service}
+                      onChange={handleChange}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     >
                       <option value="">選択してください</option>
@@ -88,6 +193,8 @@ export default function Contact() {
                       id="message"
                       name="message"
                       rows={5}
+                      value={formData.message}
+                      onChange={handleChange}
                       required
                       className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       placeholder="ご相談内容を詳しくお聞かせください"
@@ -99,6 +206,8 @@ export default function Contact() {
                       id="privacy"
                       name="privacy"
                       type="checkbox"
+                      checked={formData.privacy}
+                      onChange={handleChange}
                       required
                       className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                     />
@@ -109,9 +218,10 @@ export default function Contact() {
                   
                   <button
                     type="submit"
-                    className="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 transition-colors font-semibold"
+                    disabled={isSubmitting}
+                    className="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 transition-colors font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    送信する
+                    {isSubmitting ? '送信中...' : '送信する'}
                   </button>
                 </form>
               </div>


### PR DESCRIPTION
- Sanityに問い合わせ用のcontactスキーマを追加
- 問い合わせ送信用のAPI Route（/api/contact）を作成
- フォームに送信機能を実装（useState、エラーハンドリング含む）
- 送信成功/エラー時のメッセージ表示機能を追加

🤖 Generated with [Claude Code](https://claude.ai/code)