### PR TITLE
feat: 評価機能を削除し、注目の声をトップページ掲載に変更

### DIFF
--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -59,7 +59,6 @@ export async function getTestimonials() {
       _id,
       clientName,
       slug,
-      rating,
       comment,
       content,
       serviceType,
@@ -79,7 +78,6 @@ export async function getTestimonialBySlug(slug: string) {
       _id,
       clientName,
       slug,
-      rating,
       comment,
       content,
       serviceType,
@@ -95,11 +93,10 @@ export async function getTestimonialBySlug(slug: string) {
 // 注目お客様の声取得用のクエリ
 export async function getFeaturedTestimonials(limit: number = 3) {
   return await client.fetch(`
-    *[_type == "testimonials" && featured == true] | order(rating desc, publishedAt desc)[0...${limit}] {
+    *[_type == "testimonials" && featured == true] | order(publishedAt desc)[0...${limit}] {
       _id,
       clientName,
       slug,
-      rating,
       comment,
       serviceType,
       clientIndustry,

--- a/sanity/schemaTypes/testimonials.ts
+++ b/sanity/schemaTypes/testimonials.ts
@@ -23,13 +23,6 @@ export default defineType({
       validation: (rule) => rule.required(),
     }),
     defineField({
-      name: 'rating',
-      title: '評価',
-      type: 'number',
-      validation: (rule) => rule.required().min(1).max(5),
-      description: '1〜5の星評価',
-    }),
-    defineField({
       name: 'comment',
       title: 'お客様のコメント（見出し）',
       type: 'text',
@@ -223,9 +216,9 @@ export default defineType({
     }),
     defineField({
       name: 'featured',
-      title: '注目の声',
+      title: 'トップページ掲載',
       type: 'boolean',
-      description: 'チェックするとトップページに表示されます',
+      description: 'チェックするとトップページに表示されます（最大3件）',
     }),
     defineField({
       name: 'publishedAt',
@@ -247,12 +240,11 @@ export default defineType({
     select: {
       title: 'clientName',
       subtitle: 'serviceType',
-      rating: 'rating',
+      featured: 'featured',
       media: 'clientImage',
     },
     prepare(selection) {
-      const {title, subtitle, rating} = selection
-      const stars = '★'.repeat(rating || 0) + '☆'.repeat(5 - (rating || 0))
+      const {title, subtitle, featured} = selection
       const serviceTypes: { [key: string]: string } = {
         license: '許認可申請',
         inheritance: '相続手続き',
@@ -261,8 +253,8 @@ export default defineType({
         other: 'その他'
       }
       return {
-        title: `${title} (${stars})`,
-        subtitle: serviceTypes[subtitle] || subtitle,
+        title: title,
+        subtitle: `${serviceTypes[subtitle] || subtitle}${featured ? ' (トップページ掲載)' : ''}`,
       }
     },
   },
@@ -271,14 +263,6 @@ export default defineType({
       title: '公開日（新しい順）',
       name: 'publishedAtDesc',
       by: [
-        {field: 'publishedAt', direction: 'desc'},
-      ],
-    },
-    {
-      title: '評価（高い順）',
-      name: 'ratingDesc',
-      by: [
-        {field: 'rating', direction: 'desc'},
         {field: 'publishedAt', direction: 'desc'},
       ],
     },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -529,7 +529,6 @@ export default async function Home() {
                 _id: string;
                 clientName: string;
                 slug: { current: string };
-                rating: number;
                 comment: string;
                 serviceType: string;
                 clientIndustry?: string;
@@ -557,19 +556,9 @@ export default async function Home() {
                   
                   {/* コンテンツ部分 */}
                   <div className="p-6">
-                    <div className="flex items-center mb-4">
-                      <div className="flex text-yellow-400 text-lg">
-                        {'★'.repeat(testimonial.rating)}
-                        {'☆'.repeat(5 - testimonial.rating)}
-                      </div>
-                      <span className="ml-2 text-sm text-gray-600">({testimonial.rating}/5)</span>
-                    </div>
                     <div className="mb-4">
                       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                         {serviceTypeLabels[testimonial.serviceType] || testimonial.serviceType}
-                      </span>
-                      <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                        注目の声
                       </span>
                     </div>
                     <h3 className="text-lg font-semibold text-gray-900 mb-2">{testimonial.clientName}</h3>
@@ -616,12 +605,6 @@ export default async function Home() {
                   
                   {/* コンテンツ部分 */}
                   <div className="p-6">
-                    <div className="flex items-center mb-4">
-                      <div className="flex text-yellow-400 text-lg">
-                        ★★★★★
-                      </div>
-                      <span className="ml-2 text-sm text-gray-600">(5/5)</span>
-                    </div>
                     <div className="mb-4">
                       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                         許認可申請
@@ -646,12 +629,6 @@ export default async function Home() {
                   
                   {/* コンテンツ部分 */}
                   <div className="p-6">
-                    <div className="flex items-center mb-4">
-                      <div className="flex text-yellow-400 text-lg">
-                        ★★★★★
-                      </div>
-                      <span className="ml-2 text-sm text-gray-600">(5/5)</span>
-                    </div>
                     <div className="mb-4">
                       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                         相続手続き
@@ -676,12 +653,6 @@ export default async function Home() {
                   
                   {/* コンテンツ部分 */}
                   <div className="p-6">
-                    <div className="flex items-center mb-4">
-                      <div className="flex text-yellow-400 text-lg">
-                        ★★★★★
-                      </div>
-                      <span className="ml-2 text-sm text-gray-600">(5/5)</span>
-                    </div>
                     <div className="mb-4">
                       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                         会社設立

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -81,15 +81,13 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
 
       {/* Main Content */}
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="bg-white rounded-lg shadow-sm p-8 relative">
-          {/* Date in top right */}
-          <div className="absolute top-8 right-8">
-            <time className="text-sm text-gray-500">
+        <div className="bg-white rounded-lg shadow-sm p-8">
+          {/* Comment (Heading) */}
+          <div className="mb-6 relative">
+            {/* Date in top left of heading */}
+            <time className="absolute -top-6 left-0 text-sm text-gray-500">
               {new Date(testimonial.publishedAt).toLocaleDateString('ja-JP')}
             </time>
-          </div>
-          {/* Comment (Heading) */}
-          <div className="mb-6">
             <h2 className="text-2xl font-bold text-gray-900 text-center">
               {testimonial.comment}
             </h2>
@@ -159,18 +157,12 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
 
           {/* Navigation */}
           <div className="mt-12 pt-8 border-t border-gray-200">
-            <div className="flex justify-between items-center">
+            <div>
               <Link
                 href="/testimonials"
                 className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
               >
                 ← お客様の声一覧に戻る
-              </Link>
-              <Link
-                href="/contact"
-                className="inline-flex items-center px-6 py-3 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
-              >
-                無料相談のお申し込み
               </Link>
             </div>
           </div>

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -82,6 +82,13 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
       {/* Main Content */}
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="bg-white rounded-lg shadow-sm p-8">
+          {/* Comment (Heading) */}
+          <div className="mb-6">
+            <h2 className="text-2xl font-bold text-gray-900 text-center">
+              {testimonial.comment}
+            </h2>
+          </div>
+
           {/* Client Image */}
           {testimonial.clientImage && (
             <div className="mb-8">
@@ -107,24 +114,11 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                   {serviceTypeLabels[testimonial.serviceType] || testimonial.serviceType}
                 </span>
-                {testimonial.featured && (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                    注目の声
-                  </span>
-                )}
               </div>
             </div>
 
             <h1 className="text-3xl font-bold text-gray-900 mb-6">{testimonial.clientName}のご感想</h1>
 
-            {/* Rating */}
-            <div className="flex items-center mb-6">
-              <div className="flex text-yellow-400 text-2xl mr-4">
-                {'★'.repeat(testimonial.rating)}
-                {'☆'.repeat(5 - testimonial.rating)}
-              </div>
-              <span className="text-lg text-gray-600">({testimonial.rating}/5)</span>
-            </div>
 
             {/* Client Info */}
             <div className="bg-gray-50 rounded-lg p-6">
@@ -160,12 +154,6 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
           <div className="prose prose-lg max-w-none">
             <h2 className="text-xl font-semibold text-gray-900 mb-4">お客様のご感想</h2>
             
-            {/* 見出し的なコメント */}
-            <div className="bg-blue-50 border-l-4 border-blue-400 p-6 rounded-r-lg mb-8">
-              <div className="text-gray-700 leading-relaxed font-medium">
-                {testimonial.comment}
-              </div>
-            </div>
             
             {/* 本文（Portable Text） */}
             {testimonial.content && testimonial.content.length > 0 && (

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -81,7 +81,13 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
 
       {/* Main Content */}
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="bg-white rounded-lg shadow-sm p-8">
+        <div className="bg-white rounded-lg shadow-sm p-8 relative">
+          {/* Date in top right */}
+          <div className="absolute top-8 right-8">
+            <time className="text-sm text-gray-500">
+              {new Date(testimonial.publishedAt).toLocaleDateString('ja-JP')}
+            </time>
+          </div>
           {/* Comment (Heading) */}
           <div className="mb-6">
             <h2 className="text-2xl font-bold text-gray-900 text-center">
@@ -106,18 +112,6 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
 
           {/* Testimonial Header */}
           <header className="mb-8">
-            <div className="flex items-center justify-between mb-6">
-              <div className="flex items-center space-x-4">
-                <time className="text-sm text-gray-500">
-                  {new Date(testimonial.publishedAt).toLocaleDateString('ja-JP')}
-                </time>
-                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                  {serviceTypeLabels[testimonial.serviceType] || testimonial.serviceType}
-                </span>
-              </div>
-            </div>
-
-            <h1 className="text-3xl font-bold text-gray-900 mb-6">{testimonial.clientName}のご感想</h1>
 
 
             {/* Client Info */}
@@ -152,9 +146,6 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
 
           {/* Testimonial Content */}
           <div className="prose prose-lg max-w-none">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">お客様のご感想</h2>
-            
-            
             {/* 本文（Portable Text） */}
             {testimonial.content && testimonial.content.length > 0 && (
               <div className="mt-8">

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -143,7 +143,7 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
           </header>
 
           {/* Testimonial Content */}
-          <div className="prose prose-lg max-w-none">
+          <div className="prose prose-lg max-w-none mt-8">
             {/* 本文（Portable Text） */}
             {testimonial.content && testimonial.content.length > 0 && (
               <div className="mt-8">

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -77,7 +77,6 @@ export default async function TestimonialsPage() {
             _id: string;
             clientName: string;
             slug: { current: string };
-            rating: number;
             comment: string;
             serviceType: string;
             clientIndustry?: string;
@@ -106,25 +105,12 @@ export default async function TestimonialsPage() {
               
               {/* コンテンツ部分 */}
               <div className="p-6">
-                {/* Rating */}
-                <div className="flex items-center mb-4">
-                  <div className="flex text-yellow-400 text-lg">
-                    {'★'.repeat(testimonial.rating)}
-                    {'☆'.repeat(5 - testimonial.rating)}
-                  </div>
-                  <span className="ml-2 text-sm text-gray-600">({testimonial.rating}/5)</span>
-                </div>
 
                 {/* Service Type */}
                 <div className="mb-4">
                   <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                     {serviceTypeLabels[testimonial.serviceType] || testimonial.serviceType}
                   </span>
-                  {testimonial.featured && (
-                    <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                      注目の声
-                    </span>
-                  )}
                 </div>
 
                 {/* Client Name */}


### PR DESCRIPTION
- Sanityスキーマから評価(rating)フィールドを削除
- ホームページ、一覧ページ、詳細ページから星評価表示を削除
- 「注目の声」を「トップページ掲載」に名称変更（最大3件表示）
- 詳細ページで写真の上部にコメント（見出し）を配置
- 不要な型定義とクエリを整理