### PR TITLE
feat: スタッフ管理機能をSanity Studioで実装

### DIFF
--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -4,5 +4,6 @@ import blog from './blog'
 import serviceCategory from './serviceCategory'
 import serviceDetail from './serviceDetail'
 import contact from '../schemas/contact'
+import staff from './staff'
 
-export const schemaTypes = [news, testimonials, blog, serviceCategory, serviceDetail, contact]
+export const schemaTypes = [news, testimonials, blog, serviceCategory, serviceDetail, contact, staff]

--- a/sanity/schemaTypes/staff.ts
+++ b/sanity/schemaTypes/staff.ts
@@ -1,0 +1,108 @@
+import {defineField, defineType} from 'sanity'
+
+export default defineType({
+  name: 'staff',
+  title: 'スタッフ',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: '名前',
+      type: 'string',
+      validation: (rule) => rule.required(),
+      description: '日本語の名前（例：山田 太郎）',
+    }),
+    defineField({
+      name: 'nameRomaji',
+      title: 'ローマ字名前',
+      type: 'string',
+      validation: (rule) => rule.required(),
+      description: 'ローマ字の名前（例：YAMADA Taro）',
+    }),
+    defineField({
+      name: 'position',
+      title: '役職',
+      type: 'string',
+      description: '例：代表行政書士、行政書士、事務員など',
+    }),
+    defineField({
+      name: 'photo',
+      title: '写真',
+      type: 'image',
+      options: {
+        hotspot: true,
+      },
+      validation: (rule) => rule.required(),
+      fields: [
+        {
+          name: 'alt',
+          type: 'string',
+          title: 'Alt text',
+          description: '画像の説明（SEO用）',
+        },
+      ],
+    }),
+    defineField({
+      name: 'introduction',
+      title: '紹介文',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [
+            {title: '標準', value: 'normal'},
+            {title: '見出し3', value: 'h3'},
+            {title: '見出し4', value: 'h4'},
+          ],
+          marks: {
+            decorators: [
+              {title: '太字', value: 'strong'},
+              {title: '斜体', value: 'em'},
+            ],
+          },
+        },
+      ],
+      validation: (rule) => rule.required(),
+      description: 'プラスボタンを押したときに表示される詳細な紹介文',
+    }),
+    defineField({
+      name: 'order',
+      title: '表示順',
+      type: 'number',
+      validation: (rule) => rule.required().min(0),
+      description: '数字が小さいほど先に表示されます',
+    }),
+    defineField({
+      name: 'isActive',
+      title: '表示する',
+      type: 'boolean',
+      description: 'チェックを外すとウェブサイトに表示されません',
+      initialValue: true,
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'position',
+      media: 'photo',
+      order: 'order',
+    },
+    prepare(selection) {
+      const {title, subtitle, order} = selection
+      return {
+        title: `${order}. ${title}`,
+        subtitle: subtitle || '役職未設定',
+        media: selection.media,
+      }
+    },
+  },
+  orderings: [
+    {
+      title: '表示順',
+      name: 'orderAsc',
+      by: [
+        {field: 'order', direction: 'asc'},
+      ],
+    },
+  ],
+})

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,12 +4,46 @@ import Link from "next/link";
 import Image from "next/image";
 import Header from "@/components/Header";
 import PageHeader from "@/components/PageHeader";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { PortableText } from '@portabletext/react';
+
+interface Staff {
+  _id: string;
+  name: string;
+  nameRomaji: string;
+  position?: string;
+  photo: {
+    asset: {
+      url: string;
+    };
+    alt?: string;
+  };
+  introduction: any[];
+  order: number;
+}
 
 export default function About() {
-  const [expandedMember, setExpandedMember] = useState<number | null>(null);
+  const [expandedMember, setExpandedMember] = useState<string | null>(null);
+  const [staff, setStaff] = useState<Staff[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const members = [
+  useEffect(() => {
+    fetchStaff();
+  }, []);
+
+  const fetchStaff = async () => {
+    try {
+      const response = await fetch('/api/staff');
+      const data = await response.json();
+      setStaff(data);
+    } catch (error) {
+      console.error('Error fetching staff:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const hardcodedMembers = [
     {
       id: 1,
       name: "山田 花子｜Hanako Yamada",
@@ -48,7 +82,7 @@ export default function About() {
     }
   ];
 
-  const toggleMember = (id: number) => {
+  const toggleMember = (id: string) => {
     setExpandedMember(expandedMember === id ? null : id);
   };
 
@@ -152,15 +186,20 @@ export default function About() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-gray-900 text-center mb-12">メンバー紹介</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-12">
-            {members.map((member) => (
-              <div key={member.id} className="group">
+            {loading ? (
+              <div className="col-span-full text-center py-8">
+                <p className="text-gray-500">読み込み中...</p>
+              </div>
+            ) : staff.length > 0 ? (
+              staff.map((member) => (
+              <div key={member._id} className="group">
                 <div className="bg-gray-50 rounded-lg p-6 hover:shadow-lg transition-shadow">
                   {/* メンバー写真 - 正方形 */}
                   <div className="mb-4 relative">
                     <div className="w-full aspect-square bg-gray-200 rounded-lg overflow-hidden relative">
                       <Image 
-                        src={member.photo} 
-                        alt={member.name}
+                        src={member.photo.asset.url} 
+                        alt={member.photo.alt || member.name}
                         fill
                         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                         className="object-cover object-[center_30%]"
@@ -169,12 +208,12 @@ export default function About() {
                     
                     {/* プラスボタン - 写真の右下に配置 */}
                     <button
-                      onClick={() => toggleMember(member.id)}
+                      onClick={() => toggleMember(member._id)}
                       className="absolute bottom-2 right-2 w-8 h-8 bg-gray-700 text-white rounded-full flex items-center justify-center hover:bg-gray-800 transition-all shadow-lg"
-                      aria-label={`${member.name}の詳細を${expandedMember === member.id ? '閉じる' : '開く'}`}
+                      aria-label={`${member.name}の詳細を${expandedMember === member._id ? '閉じる' : '開く'}`}
                     >
                       <svg 
-                        className={`w-4 h-4 transition-transform duration-300 ${expandedMember === member.id ? 'rotate-45' : ''}`} 
+                        className={`w-4 h-4 transition-transform duration-300 ${expandedMember === member._id ? 'rotate-45' : ''}`} 
                         fill="none" 
                         stroke="currentColor" 
                         viewBox="0 0 24 24"
@@ -185,21 +224,82 @@ export default function About() {
                   </div>
                   
                   {/* 名前 */}
-                  <h3 className="text-xl font-semibold text-gray-900 text-center mb-3">{member.name}</h3>
+                  <h3 className="text-xl font-semibold text-gray-900 text-center mb-1">
+                    {member.name}
+                  </h3>
+                  <p className="text-sm text-gray-600 text-center mb-3">
+                    {member.nameRomaji}
+                  </p>
+                  {member.position && (
+                    <p className="text-sm text-gray-500 text-center mb-3">
+                      {member.position}
+                    </p>
+                  )}
                   
                   {/* 自己紹介（展開時） */}
                   <div className={`overflow-hidden transition-all duration-500 ${
-                    expandedMember === member.id ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+                    expandedMember === member._id ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
                   }`}>
                     <div className="pt-4 border-t border-gray-200">
-                      <p className="text-gray-600 text-sm leading-relaxed">
-                        {member.introduction}
-                      </p>
+                      <div className="text-gray-600 text-sm leading-relaxed prose prose-sm max-w-none">
+                        <PortableText value={member.introduction} />
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            ))}
+              ))
+            ) : (
+              /* フォールバック: Sanityにデータがない場合はハードコードされたデータを表示 */
+              hardcodedMembers.map((member) => (
+                <div key={member.id} className="group">
+                  <div className="bg-gray-50 rounded-lg p-6 hover:shadow-lg transition-shadow">
+                    {/* メンバー写真 - 正方形 */}
+                    <div className="mb-4 relative">
+                      <div className="w-full aspect-square bg-gray-200 rounded-lg overflow-hidden relative">
+                        <Image 
+                          src={member.photo} 
+                          alt={member.name}
+                          fill
+                          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                          className="object-cover object-[center_30%]"
+                        />
+                      </div>
+                      
+                      {/* プラスボタン - 写真の右下に配置 */}
+                      <button
+                        onClick={() => toggleMember(member.id.toString())}
+                        className="absolute bottom-2 right-2 w-8 h-8 bg-gray-700 text-white rounded-full flex items-center justify-center hover:bg-gray-800 transition-all shadow-lg"
+                        aria-label={`${member.name}の詳細を${expandedMember === member.id.toString() ? '閉じる' : '開く'}`}
+                      >
+                        <svg 
+                          className={`w-4 h-4 transition-transform duration-300 ${expandedMember === member.id.toString() ? 'rotate-45' : ''}`} 
+                          fill="none" 
+                          stroke="currentColor" 
+                          viewBox="0 0 24 24"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                        </svg>
+                      </button>
+                    </div>
+                    
+                    {/* 名前 */}
+                    <h3 className="text-xl font-semibold text-gray-900 text-center mb-3">{member.name}</h3>
+                    
+                    {/* 自己紹介（展開時） */}
+                    <div className={`overflow-hidden transition-all duration-500 ${
+                      expandedMember === member.id.toString() ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+                    }`}>
+                      <div className="pt-4 border-t border-gray-200">
+                        <p className="text-gray-600 text-sm leading-relaxed">
+                          {member.introduction}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
           </div>
         </div>
       </section>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -18,7 +18,16 @@ interface Staff {
     };
     alt?: string;
   };
-  introduction: any[];
+  introduction: Array<{
+    _type: string;
+    children?: Array<{
+      _type: string;
+      text?: string;
+      marks?: string[];
+    }>;
+    style?: string;
+    listItem?: string;
+  }>;
   order: number;
 }
 

--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@sanity/client';
+
+const client = createClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET!,
+  apiVersion: '2024-01-01',
+  useCdn: false,
+});
+
+export async function GET() {
+  try {
+    const staff = await client.fetch(`
+      *[_type == "staff" && isActive == true] | order(order asc) {
+        _id,
+        name,
+        nameRomaji,
+        position,
+        photo {
+          asset-> {
+            url
+          },
+          alt
+        },
+        introduction,
+        order
+      }
+    `);
+
+    return NextResponse.json(staff);
+  } catch (error) {
+    console.error('Error fetching staff:', error);
+    return NextResponse.json({ error: 'Failed to fetch staff' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
- スタッフスキーマを作成（名前、ローマ字名、役職、写真、紹介文）
- スタッフデータ取得APIを実装
- 事務所紹介ページをSanityデータ対応に更新
- Sanityデータがない場合のフォールバック実装