### PR TITLE
fix: お客様の声カードの高さを揃える修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -529,7 +529,7 @@ export default async function Home() {
                 publishedAt: string;
                 clientImage?: string;
               }) => (
-                <div key={testimonial._id} className="bg-white rounded-lg shadow-sm overflow-hidden">
+                <div key={testimonial._id} className="bg-white rounded-lg shadow-sm overflow-hidden flex flex-col h-full">
                   {/* 写真部分 */}
                   <Link href={`/testimonials/${testimonial.slug.current}`}>
                     <div className="aspect-[4/3] bg-gray-100 relative overflow-hidden group cursor-pointer">
@@ -550,39 +550,41 @@ export default async function Home() {
                   </Link>
                   
                   {/* コンテンツ部分 */}
-                  <div className="p-6">
+                  <div className="p-6 flex flex-col flex-grow">
                     <div className="mb-4">
                       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                         {testimonial.serviceDetail || 'サービス未設定'}
                       </span>
                     </div>
                     <h3 className="text-lg font-semibold text-gray-900 mb-2">{testimonial.clientName}</h3>
-                    <p className="text-gray-700 leading-relaxed mb-4 line-clamp-3">
+                    <p className="text-gray-700 leading-relaxed mb-4 line-clamp-3 flex-grow">
                       {testimonial.comment}
                     </p>
-                    <div className="flex items-center justify-between mb-4">
-                      <div className="text-sm text-gray-500">
-                        {testimonial.clientIndustry && (
-                          <span>{testimonial.clientIndustry}</span>
-                        )}
-                        {testimonial.clientLocation && (
-                          <span className="ml-1">({testimonial.clientLocation})</span>
-                        )}
+                    <div className="mt-auto">
+                      <div className="flex items-center justify-between mb-4">
+                        <div className="text-sm text-gray-500">
+                          {testimonial.clientIndustry && (
+                            <span>{testimonial.clientIndustry}</span>
+                          )}
+                          {testimonial.clientLocation && (
+                            <span className="ml-1">({testimonial.clientLocation})</span>
+                          )}
+                        </div>
+                        <time className="text-sm text-gray-500">
+                          {new Date(testimonial.publishedAt).toLocaleDateString('ja-JP')}
+                        </time>
                       </div>
-                      <time className="text-sm text-gray-500">
-                        {new Date(testimonial.publishedAt).toLocaleDateString('ja-JP')}
-                      </time>
-                    </div>
-                    <div className="pt-4 border-t">
-                      <Link
-                        href={`/testimonials/${testimonial.slug.current}`}
-                        className="text-blue-600 hover:text-blue-800 text-sm font-medium inline-flex items-center group"
-                      >
-                        詳細を見る
-                        <svg className="ml-1 w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                        </svg>
-                      </Link>
+                      <div className="pt-4 border-t">
+                        <Link
+                          href={`/testimonials/${testimonial.slug.current}`}
+                          className="text-blue-600 hover:text-blue-800 text-sm font-medium inline-flex items-center group"
+                        >
+                          詳細を見る
+                          <svg className="ml-1 w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                          </svg>
+                        </Link>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -57,7 +57,7 @@ export default async function TestimonialsPage() {
             publishedAt: string;
             clientImage?: string;
           }) => (
-            <div key={testimonial._id} className="bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow">
+            <div key={testimonial._id} className="bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow flex flex-col h-full">
               {/* 写真部分 */}
               <Link href={`/testimonials/${testimonial.slug.current}`}>
                 <div className="aspect-[4/3] bg-gray-100 relative overflow-hidden group cursor-pointer">
@@ -78,7 +78,7 @@ export default async function TestimonialsPage() {
               </Link>
               
               {/* コンテンツ部分 */}
-              <div className="p-6">
+              <div className="p-6 flex flex-col flex-grow">
 
                 {/* Service Type */}
                 <div className="mb-4">
@@ -90,37 +90,40 @@ export default async function TestimonialsPage() {
                 {/* Client Name */}
                 <h3 className="text-lg font-semibold text-gray-900 mb-2">{testimonial.clientName}</h3>
 
-                {/* Comment */}
-                <p className="text-gray-700 leading-relaxed mb-4 line-clamp-3">
+                {/* Comment - flex-growで空きスペースを埋める */}
+                <p className="text-gray-700 leading-relaxed mb-4 line-clamp-3 flex-grow">
                   {testimonial.comment}
                 </p>
 
-                {/* Client Info & Date */}
-                <div className="flex items-center justify-between mb-4">
-                  <div className="text-sm text-gray-500">
-                    {testimonial.clientIndustry && (
-                      <span>{testimonial.clientIndustry}</span>
-                    )}
-                    {testimonial.clientLocation && (
-                      <span className="ml-1">({testimonial.clientLocation})</span>
-                    )}
+                {/* Bottom section - 常に下部に配置 */}
+                <div className="mt-auto">
+                  {/* Client Info & Date */}
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="text-sm text-gray-500">
+                      {testimonial.clientIndustry && (
+                        <span>{testimonial.clientIndustry}</span>
+                      )}
+                      {testimonial.clientLocation && (
+                        <span className="ml-1">({testimonial.clientLocation})</span>
+                      )}
+                    </div>
+                    <time className="text-sm text-gray-500">
+                      {new Date(testimonial.publishedAt).toLocaleDateString('ja-JP')}
+                    </time>
                   </div>
-                  <time className="text-sm text-gray-500">
-                    {new Date(testimonial.publishedAt).toLocaleDateString('ja-JP')}
-                  </time>
-                </div>
 
-                {/* Read More Link */}
-                <div className="pt-4 border-t">
-                  <Link
-                    href={`/testimonials/${testimonial.slug.current}`}
-                    className="text-blue-600 hover:text-blue-800 text-sm font-medium inline-flex items-center group"
-                  >
-                    詳細を見る
-                    <svg className="ml-1 w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                    </svg>
-                  </Link>
+                  {/* Read More Link */}
+                  <div className="pt-4 border-t">
+                    <Link
+                      href={`/testimonials/${testimonial.slug.current}`}
+                      className="text-blue-600 hover:text-blue-800 text-sm font-medium inline-flex items-center group"
+                    >
+                      詳細を見る
+                      <svg className="ml-1 w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </Link>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
- カード全体にflex-colとh-fullを適用して高さを統一
- コンテンツ部分にflex-growを適用して柔軟な高さ調整を実現
- コメント部分にflex-growを適用して空きスペースを埋める
- 業種・日付・詳細リンクをmt-autoで常に下部に配置

これにより、コメントの長さに関係なく、すべてのカードの高さが揃い、
業種と日付の位置が統一されます。

🤖 Generated with [Claude Code](https://claude.ai/code)