### PR TITLE
feat: CTAセクションをコンポーネント化して全ページに適用

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import CTASection from '@/components/CTASection';
 // import { getBlogBySlug, getBlogs } from "../../../../lib/sanity";
 
 // ブログ記事の型定義
@@ -203,49 +204,18 @@ export default async function BlogDetailPage({ params }: PageProps) {
               </div>
             )}
 
-            <div className="flex justify-between items-center">
-              <Link
-                href="/blog"
-                className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-              >
-                ← お役立ち情報一覧に戻る
-              </Link>
-              <Link
-                href="/contact"
-                className="inline-flex items-center px-6 py-3 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
-              >
-                この件でご相談
-              </Link>
-            </div>
+            <Link
+              href="/blog"
+              className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            >
+              ← お役立ち情報一覧に戻る
+            </Link>
           </div>
         </article>
-
-        {/* Related CTA */}
-        <div className="mt-12">
-          <div className="bg-blue-50 rounded-lg p-8 text-center">
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">
-              記事の内容についてご質問がございますか？
-            </h2>
-            <p className="text-gray-600 mb-6">
-              具体的な手続きやご不明な点について、お気軽にご相談ください。初回相談は無料です。
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                href="/contact"
-                className="inline-flex items-center px-6 py-3 text-base font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
-              >
-                無料相談のお申し込み
-              </Link>
-              <Link
-                href="/services"
-                className="inline-flex items-center px-6 py-3 text-base font-medium text-blue-600 bg-white border border-blue-600 rounded-md hover:bg-blue-50 transition-colors"
-              >
-                サービス一覧を見る
-              </Link>
-            </div>
-          </div>
-        </div>
       </main>
+
+      {/* CTA Section */}
+      <CTASection />
 
       {/* Footer */}
       <Footer />

--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import CTASection from '@/components/CTASection';
 // import { getNewsBySlug, getNews } from "../../../../lib/sanity";
 
 // ニュースの型定義
@@ -128,23 +129,18 @@ export default async function NewsDetailPage({ params }: PageProps) {
 
           {/* Navigation */}
           <div className="mt-12 pt-8 border-t border-gray-200">
-            <div className="flex justify-between items-center">
-              <Link
-                href="/news"
-                className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-              >
-                ← お知らせ一覧に戻る
-              </Link>
-              <Link
-                href="/contact"
-                className="inline-flex items-center px-6 py-3 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
-              >
-                お問い合わせ
-              </Link>
-            </div>
+            <Link
+              href="/news"
+              className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            >
+              ← お知らせ一覧に戻る
+            </Link>
           </div>
         </div>
       </main>
+
+      {/* CTA Section */}
+      <CTASection />
 
       {/* Footer */}
       <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { sanityClient } from '@/lib/sanity.client';
 import { allServiceCategoriesQuery } from '@/lib/queries';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import CTASection from '@/components/CTASection';
 import { getFeaturedTestimonials } from '../../lib/sanity';
 
 // ISR設定：60秒ごとに再生成（開発中は短めに設定）
@@ -817,30 +818,7 @@ export default async function Home() {
       </section>
 
       {/* CTA Section */}
-      <section className="bg-gray-100 py-24">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl font-bold text-gray-900 mb-4">
-            お困りごとはございませんか？
-          </h2>
-          <p className="text-lg text-gray-600 mb-8">
-            初回相談は無料です。お気軽にお問い合わせください。
-          </p>
-          <div className="flex justify-center space-x-4">
-            <Link
-              href="/contact"
-              className="bg-blue-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors"
-            >
-              お問い合わせ
-            </Link>
-            <Link
-              href="/services"
-              className="border border-blue-600 text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-blue-50 transition-colors"
-            >
-              サービス詳細
-            </Link>
-          </div>
-        </div>
-      </section>
+      <CTASection />
 
       {/* Footer */}
       <Footer />

--- a/src/app/testimonials/[slug]/page.tsx
+++ b/src/app/testimonials/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { PortableText } from '@portabletext/react';
 import { portableTextComponents } from '@/components/PortableTextComponents';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import CTASection from '@/components/CTASection';
 
 // Next.jsのキャッシュを無効化
 export const revalidate = 0;
@@ -161,6 +162,9 @@ export default async function TestimonialDetailPage({ params }: PageProps) {
           </div>
         </div>
       </main>
+
+      {/* CTA Section */}
+      <CTASection />
 
       {/* Footer */}
       <Footer />

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+export default function CTASection() {
+  return (
+    <section className="bg-gray-100 py-24">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <h2 className="text-3xl font-bold text-gray-900 mb-4">
+          お困りごとはございませんか？
+        </h2>
+        <p className="text-lg text-gray-600 mb-8">
+          初回相談は無料です。お気軽にお問い合わせください。
+        </p>
+        <div className="flex justify-center space-x-4">
+          <Link
+            href="/contact"
+            className="bg-blue-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-blue-700 transition-colors"
+          >
+            お問い合わせ
+          </Link>
+          <Link
+            href="/services"
+            className="border border-blue-600 text-blue-600 px-8 py-3 rounded-lg font-semibold hover:bg-blue-50 transition-colors"
+          >
+            サービス詳細
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
- CTASectionコンポーネントを新規作成
- トップページの既存CTAセクションをコンポーネントに置き換え
- お知らせ詳細ページにCTAを追加し、お問い合わせボタンを削除
- お客様の声詳細ページにCTAを追加
- お役立ち情報詳細ページにCTAを追加し、「この件でご相談」ボタンとRelated CTAセクションを削除

これにより、全ページで統一されたCTAセクションが表示され、ユーザーが相談や問い合わせをしやすくなります。

🤖 Generated with [Claude Code](https://claude.ai/code)