### PR TITLE
feat: お役立ち情報の本文にリッチコンテンツ機能を追加

### DIFF
--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -132,7 +132,9 @@ export async function getBlogBySlug(slug: string) {
       publishedAt,
       updatedAt,
       metaDescription,
-      featuredImage
+      featuredImage,
+      showToc,
+      tocTitle
     }
   `, { slug })
 }

--- a/sanity/schemaTypes/blog.ts
+++ b/sanity/schemaTypes/blog.ts
@@ -33,33 +33,74 @@ export default defineType({
       name: 'content',
       title: '本文',
       type: 'array',
+      description: 'ブログのようなリッチな本文を記載できます',
       of: [
         {
           type: 'block',
           styles: [
-            {title: '標準', value: 'normal'},
+            {title: '通常', value: 'normal'},
             {title: '見出し1', value: 'h1'},
             {title: '見出し2', value: 'h2'},
             {title: '見出し3', value: 'h3'},
             {title: '見出し4', value: 'h4'},
-            {title: '引用', value: 'blockquote'},
+            {title: '見出し5', value: 'h5'},
+            {title: '見出し6', value: 'h6'},
+          ],
+          lists: [
+            {title: '箇条書き', value: 'bullet'},
+            {title: '番号付きリスト', value: 'number'},
           ],
           marks: {
             decorators: [
               {title: '太字', value: 'strong'},
               {title: '斜体', value: 'em'},
               {title: '下線', value: 'underline'},
+              {title: 'コード', value: 'code'},
             ],
             annotations: [
               {
-                title: 'リンク',
                 name: 'link',
                 type: 'object',
+                title: 'リンク',
                 fields: [
                   {
-                    title: 'URL',
                     name: 'href',
                     type: 'url',
+                    title: 'URL',
+                  },
+                ],
+              },
+              {
+                name: 'color',
+                type: 'object',
+                title: '文字色',
+                fields: [
+                  {
+                    name: 'hex',
+                    type: 'string',
+                    title: '色',
+                    description: '例: #ff0000',
+                    validation: (rule) => rule.regex(/^#[0-9a-fA-F]{6}$/),
+                  },
+                ],
+              },
+              {
+                name: 'highlight',
+                type: 'object',
+                title: '背景色',
+                fields: [
+                  {
+                    name: 'color',
+                    type: 'string',
+                    title: '色',
+                    options: {
+                      list: [
+                        {title: '黄色', value: 'yellow'},
+                        {title: 'ピンク', value: 'pink'},
+                        {title: '水色', value: 'lightblue'},
+                        {title: '薄緑', value: 'lightgreen'},
+                      ],
+                    },
                   },
                 ],
               },
@@ -68,13 +109,78 @@ export default defineType({
         },
         {
           type: 'image',
-          options: {hotspot: true},
           fields: [
             {
               name: 'alt',
               type: 'string',
-              title: 'Alt text',
-              description: '画像の説明（SEO用）',
+              title: '代替テキスト',
+              description: 'アクセシビリティのための画像説明',
+              validation: (rule) => rule.required(),
+            },
+            {
+              name: 'caption',
+              type: 'string',
+              title: 'キャプション',
+              description: '画像の下に表示される説明文',
+            },
+          ],
+        },
+        {
+          name: 'youtube',
+          type: 'object',
+          title: 'YouTube動画',
+          fields: [
+            {
+              name: 'url',
+              type: 'url',
+              title: 'YouTube URL',
+              validation: (rule) => rule.required(),
+            },
+          ],
+        },
+        {
+          name: 'code',
+          type: 'object',
+          title: 'コードブロック',
+          fields: [
+            {
+              name: 'language',
+              type: 'string',
+              title: '言語',
+              options: {
+                list: [
+                  {title: 'JavaScript', value: 'javascript'},
+                  {title: 'TypeScript', value: 'typescript'},
+                  {title: 'HTML', value: 'html'},
+                  {title: 'CSS', value: 'css'},
+                  {title: 'Python', value: 'python'},
+                  {title: 'その他', value: 'text'},
+                ],
+              },
+            },
+            {
+              name: 'code',
+              type: 'text',
+              title: 'コード',
+              rows: 10,
+            },
+          ],
+        },
+        {
+          name: 'blockquote',
+          type: 'object',
+          title: '引用',
+          fields: [
+            {
+              name: 'text',
+              type: 'text',
+              title: '引用文',
+              rows: 3,
+            },
+            {
+              name: 'cite',
+              type: 'string',
+              title: '引用元',
             },
           ],
         },
@@ -155,6 +261,21 @@ export default defineType({
           description: '画像の説明（SEO用）',
         },
       ],
+    }),
+    defineField({
+      name: 'showToc',
+      title: '目次を表示',
+      type: 'boolean',
+      description: '本文にH2/H3見出しがある場合、自動的に目次を生成して表示します',
+      initialValue: true,
+    }),
+    defineField({
+      name: 'tocTitle',
+      title: '目次タイトル',
+      type: 'string',
+      description: '目次のタイトル（デフォルト: 目次）',
+      initialValue: '目次',
+      hidden: ({document}) => !document?.showToc,
     }),
   ],
   preview: {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -153,7 +153,7 @@ export default async function BlogDetailPage({ params }: PageProps) {
 
             {blog.tags && blog.tags.length > 0 && (
               <div className="flex flex-wrap gap-2">
-                {blog.tags.map((tag, index) => (
+                {blog.tags.map((tag: string, index: number) => (
                   <span key={index} className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-gray-100 text-gray-700">
                     #{tag}
                   </span>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,35 +3,11 @@ import { notFound } from "next/navigation";
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import CTASection from '@/components/CTASection';
-// import { getBlogBySlug, getBlogs } from "../../../../lib/sanity";
+import TableOfContents from '@/components/TableOfContents';
+import PortableTextWithToc from '@/components/PortableTextWithToc';
+import { generateTocFromContent } from '@/utils/generateToc';
+import { getBlogBySlug, getBlogs } from "../../../../lib/sanity";
 
-// ブログ記事の型定義
-interface Blog {
-  _id: string;
-  title: string;
-  slug: { current: string };
-  excerpt: string;
-  content?: {
-    _type: string;
-    children: {
-      _type: string;
-      text: string;
-    }[];
-  }[];
-  category: string;
-  tags?: string[];
-  featured?: boolean;
-  readingTime?: number;
-  publishedAt: string;
-  updatedAt?: string;
-  metaDescription?: string;
-  featuredImage?: {
-    asset: {
-      url: string;
-    };
-    alt?: string;
-  };
-}
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -40,7 +16,10 @@ interface PageProps {
 export default async function BlogDetailPage({ params }: PageProps) {
   const { slug } = await params;
   
-  // 一時的にテストデータを使用
+  // Sanityからブログ記事を取得
+  const blog = await getBlogBySlug(slug);
+  
+  /* 削除: テストデータ
   const blog: Blog | null = slug === "kensetsugyo-kyoka-shutoku-hoho" ? {
     _id: "test1",
     title: "建設業許可の取得方法と必要書類を徹底解説",
@@ -105,7 +84,7 @@ export default async function BlogDetailPage({ params }: PageProps) {
     featured: false,
     readingTime: 7,
     publishedAt: "2025-07-05"
-  } : null;
+  } : null; */
 
   if (!blog) {
     notFound();
@@ -143,8 +122,10 @@ export default async function BlogDetailPage({ params }: PageProps) {
       </nav>
 
       {/* Main Content */}
-      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <article className="bg-white rounded-lg shadow-sm p-8">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="lg:grid lg:grid-cols-4 lg:gap-8">
+          {/* Article Content */}
+          <article className="lg:col-span-3 bg-white rounded-lg shadow-sm p-8">
           {/* Article Header */}
           <header className="mb-8">
             <div className="flex items-center space-x-4 mb-6">
@@ -181,17 +162,30 @@ export default async function BlogDetailPage({ params }: PageProps) {
             )}
           </header>
 
+          {/* Table of Contents for Mobile */}
+          {blog.showToc !== false && blog.content && blog.content.length > 0 && (() => {
+            const tocItems = generateTocFromContent(blog.content);
+            if (tocItems.length > 0) {
+              return (
+                <div className="lg:hidden mb-8">
+                  <TableOfContents 
+                    items={tocItems} 
+                    title={blog.tocTitle || '目次'}
+                  />
+                </div>
+              );
+            }
+            return null;
+          })()}
+
           {/* Article Content */}
           <div className="prose prose-lg max-w-none">
-            {blog.content && blog.content.map((block, index) => (
-              <div key={index} className="mb-6">
-                {block.children?.map((child, childIndex: number) => (
-                  <div key={childIndex} className="text-gray-700 leading-relaxed whitespace-pre-line">
-                    {child.text}
-                  </div>
-                ))}
-              </div>
-            ))}
+            {blog.content && blog.content.length > 0 && (
+              <PortableTextWithToc
+                content={blog.content}
+                headingIndexRef={{ current: 0 }}
+              />
+            )}
           </div>
 
           {/* Article Footer */}
@@ -211,7 +205,26 @@ export default async function BlogDetailPage({ params }: PageProps) {
               ← お役立ち情報一覧に戻る
             </Link>
           </div>
-        </article>
+          </article>
+
+          {/* Sidebar with Table of Contents */}
+          <aside className="hidden lg:block">
+            <div className="sticky top-24">
+              {blog.showToc !== false && blog.content && blog.content.length > 0 && (() => {
+                const tocItems = generateTocFromContent(blog.content);
+                if (tocItems.length > 0) {
+                  return (
+                    <TableOfContents 
+                      items={tocItems} 
+                      title={blog.tocTitle || '目次'}
+                    />
+                  );
+                }
+                return null;
+              })()}
+            </div>
+          </aside>
+        </div>
       </main>
 
       {/* CTA Section */}
@@ -221,4 +234,13 @@ export default async function BlogDetailPage({ params }: PageProps) {
       <Footer />
     </div>
   );
+}
+
+// 静的パスの生成
+export async function generateStaticParams() {
+  const blogs = await getBlogs();
+  
+  return blogs.map((blog: { slug: { current: string } }) => ({
+    slug: blog.slug.current,
+  }));
 }


### PR DESCRIPTION
- お客様の声と同等のリッチテキスト機能を実装
  - YouTube動画埋め込み
  - コードブロック
  - 引用ブロック
  - 文字色・背景色のハイライト
  - H1〜H6の見出し
  - 箇条書き・番号付きリスト
- 目次機能を追加（H2/H3見出しから自動生成）
- レスポンシブ対応（モバイルとデスクトップで目次の表示位置を最適化）
- テストデータを削除してSanityから実データを取得

🤖 Generated with [Claude Code](https://claude.ai/code)