### PR TITLE
feat: サービスカテゴリーの専門性アピールを削除

### DIFF
--- a/sanity/schemaTypes/serviceCategory.ts
+++ b/sanity/schemaTypes/serviceCategory.ts
@@ -51,12 +51,6 @@ export default {
       title: 'キャッチコピー',
     },
     {
-      name: 'expertiseDescription',
-      type: 'array',
-      title: '専門性のアピール',
-      of: [{ type: 'block' }],
-    },
-    {
       name: 'faq',
       type: 'array',
       title: 'よくある質問',

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -144,9 +144,6 @@ export default async function CategoryPage({ params }: Props) {
         <h1 className="text-3xl font-bold mb-4">
           【専門家がサポート】{data.title}のご案内
         </h1>
-        {data.expertiseDescription && (
-          <PortableText value={data.expertiseDescription} />
-        )}
       </section>
 
       {/* 中項目テーブル */}

--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { ServiceCategory } from '@/lib/types';
 import { getOptimizedImageProps } from '@/lib/sanityImage';
-import { PortableText } from '@portabletext/react';
 
 interface CategoryCardProps {
   category: ServiceCategory;
@@ -58,13 +57,6 @@ export default function CategoryCard({ category }: CategoryCardProps) {
         <h3 className="text-xl font-bold text-gray-900 mb-2">{category.title}</h3>
         {category.catchphrase && (
           <p className="text-gray-600 text-sm mb-4">{category.catchphrase}</p>
-        )}
-
-        {/* 専門性のアピール */}
-        {category.expertiseDescription && (
-          <div className="text-gray-700 text-sm mb-4 prose prose-sm max-w-none">
-            <PortableText value={category.expertiseDescription} />
-          </div>
         )}
 
         {/* 中項目プレビュー */}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -24,7 +24,6 @@ export const allServiceCategoriesQuery = `
     title,
     "slug": slug.current,
     catchphrase,
-    expertiseDescription,
     "iconUrl": icon.asset->url + "?w=400&h=300&fit=max&auto=format",
     icon {
       asset-> {
@@ -64,7 +63,6 @@ export const categoryPageQuery = `
     title,
     "slug": slug.current,
     catchphrase,
-    expertiseDescription,
     faq[] {
       question,
       answer

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,7 +51,6 @@ export interface ServiceCategory {
   imageUrl?: string;
   iconUrl?: string;
   catchphrase?: string;
-  expertiseDescription?: PortableTextBlock[];
   faq?: FaqItem[];
   services?: ServiceDetailLite[];
   previewServices?: Array<{


### PR DESCRIPTION
- SanityスキーマからexpertiseDescriptionフィールドを削除
- クエリから専門性アピールフィールドを削除
- 型定義から専門性アピールを削除
- CategoryCardコンポーネントから専門性アピール表示を削除
- サービスカテゴリーページから専門性アピール表示を削除

🤖 Generated with [Claude Code](https://claude.ai/code)