### PR TITLE
feat: サービスカテゴリーページから実績紹介バナーを削除

### DIFF
--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -158,16 +158,6 @@ export default async function CategoryPage({ params }: Props) {
         </section>
       )}
 
-      {/* 実績紹介バナー */}
-      <div className="text-center py-8 bg-gray-100 rounded-xl">
-        <a
-          href={`/cases?category=${data.slug}`}
-          className="text-blue-700 hover:underline font-medium"
-        >
-          {data.title}に関する実績を見る ＞
-        </a>
-      </div>
-
       {/* CTA */}
       <CtaBanner categoryTitle={data.title} />
       </div>


### PR DESCRIPTION
- 実績ページがまだ実装されていないため、実績紹介バナーを削除
- お客様の声が充実してきた段階で実装を検討する方針

🤖 Generated with [Claude Code](https://claude.ai/code)