### PR TITLE
feat: トップページの各セクションタイトルデザインを統一

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,7 +143,11 @@ export default async function Home() {
       {/* Features Section */}
       <section className="bg-gray-50 py-24">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold text-gray-900 text-center mb-12">当事務所の特徴</h2>
+          <div className="text-center mb-12">
+            <h2 className="text-3xl font-bold text-gray-900 mb-4">当事務所の特徴</h2>
+            <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
+            <p className="text-sm text-gray-600 tracking-widest">OUR STRENGTHS</p>
+          </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {/* 申請実績 */}
             <div className="bg-white rounded-lg border border-gray-200 p-8 hover:border-gray-300 hover:shadow-md transition-all duration-300">
@@ -224,6 +228,8 @@ export default async function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">主要サービス</h2>
+            <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
+            <p className="text-sm text-gray-600 tracking-widest mb-6">OUR SERVICES</p>
             <p className="text-lg text-gray-600">
               豊富な経験と専門知識で、お客様のニーズにお応えします
             </p>
@@ -458,6 +464,8 @@ export default async function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">最新のお知らせ</h2>
+            <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
+            <p className="text-sm text-gray-600 tracking-widest mb-6">NEWS & UPDATES</p>
             <p className="text-lg text-gray-600">
               事務所からの重要なお知らせをご確認ください
             </p>
@@ -512,6 +520,8 @@ export default async function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">お客様の声</h2>
+            <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
+            <p className="text-sm text-gray-600 tracking-widest mb-6">CUSTOMER TESTIMONIALS</p>
             <p className="text-lg text-gray-600">
               ご利用いただいたお客様からの貴重なご意見をご紹介します
             </p>
@@ -684,6 +694,8 @@ export default async function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">お役立ち情報</h2>
+            <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
+            <p className="text-sm text-gray-600 tracking-widest mb-6">BLOG</p>
             <p className="text-lg text-gray-600">
               行政書士業務に関する有用な情報をお届けします
             </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -229,15 +229,7 @@ export default async function Home() {
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">主要サービス</h2>
             <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
-            <p className="text-sm text-gray-600 tracking-widest mb-6">OUR SERVICES</p>
-            <div className="mt-8 bg-blue-50 rounded-lg p-4 inline-block">
-              <p className="text-gray-700 flex items-center">
-                <svg className="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                まずは、お困りの内容に該当するサービスをクリックしてください
-              </p>
-            </div>
+            <p className="text-sm text-gray-600 tracking-widest">OUR SERVICES</p>
           </div>
           
           {/* Sanityからのデータがある場合は動的に表示 */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -230,9 +230,6 @@ export default async function Home() {
             <h2 className="text-3xl font-bold text-gray-900 mb-4">主要サービス</h2>
             <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
             <p className="text-sm text-gray-600 tracking-widest mb-6">OUR SERVICES</p>
-            <p className="text-lg text-gray-600">
-              豊富な経験と専門知識で、お客様のニーズにお応えします
-            </p>
             <div className="mt-8 bg-blue-50 rounded-lg p-4 inline-block">
               <p className="text-gray-700 flex items-center">
                 <svg className="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -465,10 +462,7 @@ export default async function Home() {
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">最新のお知らせ</h2>
             <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
-            <p className="text-sm text-gray-600 tracking-widest mb-6">NEWS & UPDATES</p>
-            <p className="text-lg text-gray-600">
-              事務所からの重要なお知らせをご確認ください
-            </p>
+            <p className="text-sm text-gray-600 tracking-widest">NEWS & UPDATES</p>
           </div>
           {latestNews.length > 0 ? (
             <div className="bg-white rounded-lg shadow-sm overflow-hidden">
@@ -521,10 +515,7 @@ export default async function Home() {
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">お客様の声</h2>
             <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
-            <p className="text-sm text-gray-600 tracking-widest mb-6">CUSTOMER TESTIMONIALS</p>
-            <p className="text-lg text-gray-600">
-              ご利用いただいたお客様からの貴重なご意見をご紹介します
-            </p>
+            <p className="text-sm text-gray-600 tracking-widest">CUSTOMER TESTIMONIALS</p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {featuredTestimonials.length > 0 ? (
@@ -695,10 +686,7 @@ export default async function Home() {
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold text-gray-900 mb-4">お役立ち情報</h2>
             <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
-            <p className="text-sm text-gray-600 tracking-widest mb-6">BLOG</p>
-            <p className="text-lg text-gray-600">
-              行政書士業務に関する有用な情報をお届けします
-            </p>
+            <p className="text-sm text-gray-600 tracking-widest">BLOG</p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <article className="bg-gray-50 rounded-lg p-6 hover:shadow-md transition-shadow">


### PR DESCRIPTION
- 日本語タイトルの下に黒いライン（w-20 h-1 bg-gray-900）を追加
- 英語サブタイトルを大文字で表示（tracking-widest）
- 以下のセクションに適用:
  - 当事務所の特徴 (OUR STRENGTHS)
  - 主要サービス (OUR SERVICES)
  - 最新のお知らせ (NEWS & UPDATES)
  - お客様の声 (CUSTOMER TESTIMONIALS)
  - お役立ち情報 (BLOG)

🤖 Generated with [Claude Code](https://claude.ai/code)