### PR TITLE
feat: サービスセクションのボタンデザインを統一

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -417,12 +417,9 @@ export default async function Home() {
           <div className="text-center mt-12">
             <Link 
               href="/services" 
-              className="inline-flex items-center px-6 py-3 bg-gray-900 text-white font-medium rounded-lg hover:bg-gray-800 transition-colors"
+              className="inline-flex items-center px-6 py-3 border border-blue-600 text-blue-600 font-semibold rounded-lg hover:bg-blue-50 transition-colors"
             >
               すべてのサービスを見る
-              <svg className="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-              </svg>
             </Link>
           </div>
         </div>


### PR DESCRIPTION
- 「すべてのサービスを見る」ボタンのデザインを「すべてのお客様の声を見る」ボタンと統一
- 青色のボーダーと青色のテキストを使用したデザインに変更
- ホバー時に青色の背景色が表示されるように設定

🤖 Generated with [Claude Code](https://claude.ai/code)