### PR TITLE
feat: CTAセクションにサービス名カスタマイズ機能を追加

### DIFF
--- a/src/app/services/[category]/[slug]/page.tsx
+++ b/src/app/services/[category]/[slug]/page.tsx
@@ -350,10 +350,10 @@ export default async function ServiceDetailPage({ params }: Props) {
             </div>
           </section>
         )}
-
-        {/* CTA */}
-        <NewCTASection serviceName={data.title} />
       </main>
+
+      {/* CTA */}
+      <NewCTASection serviceName={data.title} />
 
       <UnifiedFooter />
     </div>

--- a/src/app/services/[category]/[slug]/page.tsx
+++ b/src/app/services/[category]/[slug]/page.tsx
@@ -13,7 +13,7 @@ import Header from '@/components/Header';
 import Breadcrumbs from '@/components/Breadcrumbs';
 import { FaqAccordion } from '@/components/FaqAccordion';
 import RelatedServices from '@/components/RelatedServices';
-import CtaBanner from '@/components/CtaBanner';
+import NewCTASection from '@/components/NewCTASection';
 import Script from 'next/script';
 import { generateTocFromContent } from '@/utils/generateToc';
 import TableOfContents from '@/components/TableOfContents';
@@ -352,7 +352,7 @@ export default async function ServiceDetailPage({ params }: Props) {
         )}
 
         {/* CTA */}
-        <CtaBanner serviceTitle={data.title} />
+        <NewCTASection serviceName={data.title} />
       </main>
 
       <UnifiedFooter />

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -7,7 +7,7 @@ import { ServiceCategory } from '@/lib/types';
 import Header from '@/components/Header';
 import { FaqAccordion } from '@/components/FaqAccordion';
 import Breadcrumbs from '@/components/Breadcrumbs';
-import CtaBanner from '@/components/CtaBanner';
+import NewCTASection from '@/components/NewCTASection';
 import ServiceTable from '@/components/ServiceTable';
 import Script from 'next/script';
 import UnifiedFooter from '@/components/UnifiedFooter';
@@ -159,7 +159,7 @@ export default async function CategoryPage({ params }: Props) {
       )}
 
       {/* CTA */}
-      <CtaBanner categoryTitle={data.title} />
+      <NewCTASection serviceName={data.title} />
       </div>
 
       <UnifiedFooter />

--- a/src/app/services/[category]/page.tsx
+++ b/src/app/services/[category]/page.tsx
@@ -158,9 +158,10 @@ export default async function CategoryPage({ params }: Props) {
         </section>
       )}
 
+      </div>
+
       {/* CTA */}
       <NewCTASection serviceName={data.title} />
-      </div>
 
       <UnifiedFooter />
     </div>

--- a/src/components/NewCTASection.tsx
+++ b/src/components/NewCTASection.tsx
@@ -1,6 +1,10 @@
 import Link from 'next/link';
 
-export default function NewCTASection() {
+interface NewCTASectionProps {
+  serviceName?: string;
+}
+
+export default function NewCTASection({ serviceName }: NewCTASectionProps) {
   return (
     <section 
       className="relative pt-40 pb-24 bg-cover bg-gray-100"
@@ -18,7 +22,10 @@ export default function NewCTASection() {
           {/* Title Section */}
           <div className="text-center mb-12">
             <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-6 leading-relaxed">
-              初回無料相談、まずはお気軽に相談ください
+              {serviceName 
+                ? `${serviceName}について無料で相談する`
+                : '初回無料相談、まずはお気軽に相談ください'
+              }
             </h2>
             <p className="text-base text-gray-600">
               テストテストテスト文章を入力してください


### PR DESCRIPTION
- NewCTASectionコンポーネントにserviceNameプロップを追加
- serviceNameが指定された場合は「〇〇について無料で相談する」と表示
- サービスカテゴリページと詳細ページで動的にサービス名を表示
- CtaBannerコンポーネントをNewCTASectionに置き換え