### PR TITLE
fix: フッターのサービスカテゴリー間のスペースを統一

### DIFF
--- a/src/components/UnifiedFooter.tsx
+++ b/src/components/UnifiedFooter.tsx
@@ -75,7 +75,7 @@ export default function UnifiedFooter() {
           {/* 第2列: サービス */}
           <div className="md:col-span-2">
             <h3 className="text-lg font-semibold mb-4">サービス</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2">
+            <div className="space-y-2">
               {loading ? (
                 // ローディング中の表示
                 <div className="animate-pulse">

--- a/src/components/UnifiedFooter.tsx
+++ b/src/components/UnifiedFooter.tsx
@@ -75,7 +75,7 @@ export default function UnifiedFooter() {
           {/* 第2列: サービス */}
           <div className="md:col-span-2">
             <h3 className="text-lg font-semibold mb-4">サービス</h3>
-            <div className="space-y-2">
+            <div className="md:columns-2 md:gap-x-6 space-y-2">
               {loading ? (
                 // ローディング中の表示
                 <div className="animate-pulse">
@@ -86,7 +86,7 @@ export default function UnifiedFooter() {
               ) : serviceCategories.length > 0 ? (
                 // Sanityデータがある場合
                 serviceCategories.map((category) => (
-                  <div key={category._id} className="mb-2">
+                  <div key={category._id} className="mb-2 break-inside-avoid">
                     <Link 
                       href={`/services/${category.slug}`}
                       className="text-gray-300 hover:text-white font-medium transition-colors block"

--- a/src/components/UnifiedFooter.tsx
+++ b/src/components/UnifiedFooter.tsx
@@ -86,7 +86,7 @@ export default function UnifiedFooter() {
               ) : serviceCategories.length > 0 ? (
                 // Sanityデータがある場合
                 serviceCategories.map((category) => (
-                  <div key={category._id}>
+                  <div key={category._id} className="mb-3">
                     <Link 
                       href={`/services/${category.slug}`}
                       className="text-gray-300 hover:text-white font-medium transition-colors block mb-2"
@@ -94,7 +94,7 @@ export default function UnifiedFooter() {
                       {category.title}
                     </Link>
                     {category.subcategories && category.subcategories.length > 0 && (
-                      <ul className="ml-4 space-y-1 mb-3">
+                      <ul className="ml-4 space-y-1">
                         {category.subcategories.map((sub) => (
                           <li key={sub._id}>
                             <Link

--- a/src/components/UnifiedFooter.tsx
+++ b/src/components/UnifiedFooter.tsx
@@ -75,7 +75,7 @@ export default function UnifiedFooter() {
           {/* 第2列: サービス */}
           <div className="md:col-span-2">
             <h3 className="text-lg font-semibold mb-4">サービス</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2">
               {loading ? (
                 // ローディング中の表示
                 <div className="animate-pulse">
@@ -86,15 +86,15 @@ export default function UnifiedFooter() {
               ) : serviceCategories.length > 0 ? (
                 // Sanityデータがある場合
                 serviceCategories.map((category) => (
-                  <div key={category._id} className="mb-3">
+                  <div key={category._id} className="mb-2">
                     <Link 
                       href={`/services/${category.slug}`}
-                      className="text-gray-300 hover:text-white font-medium transition-colors block mb-2"
+                      className="text-gray-300 hover:text-white font-medium transition-colors block"
                     >
                       {category.title}
                     </Link>
                     {category.subcategories && category.subcategories.length > 0 && (
-                      <ul className="ml-4 space-y-1">
+                      <ul className="ml-4 space-y-1 mt-1">
                         {category.subcategories.map((sub) => (
                           <li key={sub._id}>
                             <Link


### PR DESCRIPTION
- 中項目の有無に関わらず一定のスペースを確保
- 各カテゴリーの親要素にmb-3クラスを追加
- サブカテゴリーリストからmb-3を削除

🤖 Generated with [Claude Code](https://claude.ai/code)