### PR TITLE
feat: サービステーブルをモバイルでカード形式に変更

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -5,10 +5,10 @@ interface PageHeaderProps {
 
 export default function PageHeader({ title, description }: PageHeaderProps) {
   return (
-    <section className="bg-[#004080] text-white py-16">
+    <section className="bg-[#004080] text-white py-8 sm:py-12 lg:py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h1 className="text-4xl font-bold mb-4">{title}</h1>
-        <p className="text-xl">{description}</p>
+        <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold mb-2 sm:mb-4">{title}</h1>
+        <p className="text-base sm:text-lg lg:text-xl">{description}</p>
       </div>
     </section>
   );

--- a/src/components/ServiceTable.tsx
+++ b/src/components/ServiceTable.tsx
@@ -9,8 +9,10 @@ interface ServiceTableProps {
 export default function ServiceTable({ services, categorySlug }: ServiceTableProps) {
   return (
     <section>
-      <h2 className="text-2xl font-semibold mb-6">サービス一覧</h2>
-      <div className="bg-white shadow-sm rounded-lg overflow-x-auto">
+      <h2 className="text-xl sm:text-2xl font-semibold mb-4 sm:mb-6">サービス一覧</h2>
+      
+      {/* デスクトップ用テーブル表示 */}
+      <div className="hidden md:block bg-white shadow-sm rounded-lg overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
@@ -61,6 +63,45 @@ export default function ServiceTable({ services, categorySlug }: ServiceTablePro
             ))}
           </tbody>
         </table>
+      </div>
+
+      {/* モバイル用カード表示 */}
+      <div className="md:hidden space-y-4">
+        {services.map((service) => (
+          <div key={service._id} className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="mb-3">
+              <h3 className="text-base font-semibold text-gray-900">{service.title}</h3>
+              {service.overview && (
+                <p className="text-sm text-gray-600 mt-1">{service.overview}</p>
+              )}
+            </div>
+            
+            <div className="space-y-2 mb-4">
+              <div className="flex flex-col">
+                <span className="text-xs font-medium text-gray-500 mb-1">対象者</span>
+                <span className="text-sm text-gray-700">{service.target || '詳細をご確認ください'}</span>
+              </div>
+              
+              <div className="flex flex-col">
+                <span className="text-xs font-medium text-gray-500 mb-1">料金目安</span>
+                <span className="text-sm font-medium text-gray-900">
+                  {service.priceMin && service.priceMax
+                    ? `¥${service.priceMin.toLocaleString()}〜¥${service.priceMax.toLocaleString()}`
+                    : service.priceMin
+                    ? `¥${service.priceMin.toLocaleString()}〜`
+                    : service.priceNote ?? '個別見積り'}
+                </span>
+              </div>
+            </div>
+            
+            <Link
+              href={`/services/${categorySlug}/${service.slug}`}
+              className="block w-full text-center bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition-colors text-sm font-medium"
+            >
+              詳細を見る
+            </Link>
+          </div>
+        ))}
       </div>
     </section>
   );


### PR DESCRIPTION
- モバイル(〜md): カード形式で表示
- タブレット以上(md〜): 従来のテーブル形式を維持
- カードには全情報を見やすく配置
- 詳細ボタンを全幅表示でタップしやすく