### PR TITLE
fix: 深い階層ページの文字サイズをモバイル対応

### DIFF
--- a/src/app/services/[category]/[slug]/page.tsx
+++ b/src/app/services/[category]/[slug]/page.tsx
@@ -224,7 +224,7 @@ export default async function ServiceDetailPage({ params }: Props) {
 
         {/* ページタイトル */}
         <section aria-label="ページタイトル">
-          <h1 className="text-3xl md:text-4xl font-bold text-[#004080] mb-8">
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-[#004080] mb-6 sm:mb-8">
             {data.title}
           </h1>
         </section>
@@ -285,7 +285,7 @@ export default async function ServiceDetailPage({ params }: Props) {
         {/* よくある質問 */}
         {data.faq && data.faq.length > 0 && (
           <section aria-label="よくある質問">
-            <h2 className="text-2xl font-bold text-[#004080] mb-6">
+            <h2 className="text-xl sm:text-2xl font-bold text-[#004080] mb-4 sm:mb-6">
               よくある質問
             </h2>
             <FaqAccordion faqs={data.faq} />
@@ -295,12 +295,12 @@ export default async function ServiceDetailPage({ params }: Props) {
         {/* 関連サービス */}
         {data.related && data.related.length > 0 && (
           <section>
-            <h2 className="text-xl font-bold my-6">関連サービス</h2>
+            <h2 className="text-lg sm:text-xl font-bold my-4 sm:my-6">関連サービス</h2>
             <ul className="grid gap-4 md:grid-cols-2">
               {data.related.map((item) => (
                 <li key={item.slug}>
                   <Link href={`/services/${item.parentCategory.slug}/${item.slug}`} className="block p-4 border rounded-lg hover:bg-gray-50">
-                    <h3 className="text-lg font-semibold">{item.title}</h3>
+                    <h3 className="text-base sm:text-lg font-semibold">{item.title}</h3>
                     <p className="text-sm text-gray-600 mt-2">{item.overview}</p>
                   </Link>
                 </li>
@@ -331,7 +331,7 @@ export default async function ServiceDetailPage({ params }: Props) {
                   href={`/services/${service.categorySlug}/${service.slug}`}
                   className="group bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-all duration-300"
                 >
-                  <h3 className="font-semibold text-lg text-gray-900 mb-3 group-hover:text-[#004080] transition-colors">
+                  <h3 className="font-semibold text-base sm:text-lg text-gray-900 mb-2 sm:mb-3 group-hover:text-[#004080] transition-colors">
                     {service.title}
                   </h3>
                   {service.overview && (

--- a/src/components/PortableTextWithToc.tsx
+++ b/src/components/PortableTextWithToc.tsx
@@ -11,19 +11,19 @@ interface PortableTextWithTocProps {
 export default function PortableTextWithToc({ content, headingIndexRef }: PortableTextWithTocProps) {
   const components: PortableTextComponents = {
     block: {
-      h1: ({ children }) => <h1 className="text-3xl font-bold mt-8 mb-4">{children}</h1>,
+      h1: ({ children }) => <h1 className="text-2xl sm:text-3xl font-bold mt-6 sm:mt-8 mb-3 sm:mb-4">{children}</h1>,
       h2: ({ children }) => {
         const id = `heading-${headingIndexRef.current++}`;
-        return <h2 id={id} className="text-2xl font-bold mt-8 mb-4 scroll-mt-24">{children}</h2>;
+        return <h2 id={id} className="text-xl sm:text-2xl font-bold mt-6 sm:mt-8 mb-3 sm:mb-4 scroll-mt-24">{children}</h2>;
       },
       h3: ({ children }) => {
         const id = `heading-${headingIndexRef.current++}`;
-        return <h3 id={id} className="text-xl font-bold mt-6 mb-3 scroll-mt-24">{children}</h3>;
+        return <h3 id={id} className="text-lg sm:text-xl font-bold mt-4 sm:mt-6 mb-2 sm:mb-3 scroll-mt-24">{children}</h3>;
       },
-      h4: ({ children }) => <h4 className="text-lg font-bold mt-6 mb-3">{children}</h4>,
-      h5: ({ children }) => <h5 className="text-base font-bold mt-4 mb-2">{children}</h5>,
-      h6: ({ children }) => <h6 className="text-sm font-bold mt-4 mb-2">{children}</h6>,
-      normal: ({ children }) => <p className="mb-4 leading-relaxed">{children}</p>,
+      h4: ({ children }) => <h4 className="text-base sm:text-lg font-bold mt-4 sm:mt-6 mb-2 sm:mb-3">{children}</h4>,
+      h5: ({ children }) => <h5 className="text-sm sm:text-base font-bold mt-3 sm:mt-4 mb-2">{children}</h5>,
+      h6: ({ children }) => <h6 className="text-sm font-bold mt-3 sm:mt-4 mb-2">{children}</h6>,
+      normal: ({ children }) => <p className="text-sm sm:text-base mb-3 sm:mb-4 leading-relaxed">{children}</p>,
       blockquote: ({ children }) => (
         <blockquote className="border-l-4 border-gray-300 pl-4 my-4 italic">{children}</blockquote>
       ),


### PR DESCRIPTION
- ページタイトル: モバイル24px → タブレット30px → PC36px
- 見出しh1: モバイル24px → タブレット30px
- 見出しh2: モバイル20px → タブレット24px
- 見出しh3: モバイル18px → タブレット20px
- 本文: モバイル14px → タブレット以上16px
- マージンも画面サイズに応じて調整