### PR TITLE
feat: QAセクションにQ/Aアイコン付きアコーディオンデザインを実装

### DIFF
--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -21,31 +21,41 @@ export function FaqAccordion({ faqs }: FaqAccordionProps) {
   return (
     <div className="space-y-4">
       {faqs.map((faq, index) => (
-        <div key={index} className="border border-gray-200 rounded-lg">
+        <div key={index} className="border border-gray-200 rounded-lg overflow-hidden">
           <button
-            className="w-full px-6 py-4 text-left flex justify-between items-center hover:bg-gray-50 transition-colors"
+            className="w-full px-4 sm:px-6 py-4 text-left flex items-start gap-3 sm:gap-4 hover:bg-gray-50 transition-colors"
             onClick={() => toggleItem(index)}
           >
-            <span className="font-medium text-gray-900">{faq.question}</span>
-            <svg
-              className={`w-5 h-5 text-gray-500 transition-transform ${
-                openIndex === index ? 'rotate-180' : ''
-              }`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
+            <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#004080] rounded-full flex items-center justify-center">
+              <span className="text-white font-bold text-sm sm:text-base">Q</span>
+            </div>
+            <div className="flex-1 flex justify-between items-center">
+              <span className="font-medium text-gray-900 pr-2">{faq.question}</span>
+              <svg
+                className={`flex-shrink-0 w-5 h-5 text-gray-500 transition-transform ${
+                  openIndex === index ? 'rotate-180' : ''
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </div>
           </button>
           {openIndex === index && (
-            <div className="px-6 py-4 border-t border-gray-200">
-              <p className="text-gray-700">{faq.answer}</p>
+            <div className="px-4 sm:px-6 py-4 bg-gray-50">
+              <div className="flex items-start gap-3 sm:gap-4">
+                <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#F39800] rounded-full flex items-center justify-center">
+                  <span className="text-white font-bold text-sm sm:text-base">A</span>
+                </div>
+                <p className="text-gray-700 flex-1">{faq.answer}</p>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -26,11 +26,11 @@ export function FaqAccordion({ faqs }: FaqAccordionProps) {
             className="w-full px-4 sm:px-6 py-4 text-left flex items-start gap-3 sm:gap-4 hover:bg-gray-50 transition-colors"
             onClick={() => toggleItem(index)}
           >
-            <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#004080] rounded-full flex items-center justify-center">
+            <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#004080] rounded-full flex items-center justify-center mt-0.5">
               <span className="text-white font-bold text-sm sm:text-base">Q</span>
             </div>
             <div className="flex-1 flex justify-between items-center">
-              <span className="font-medium text-gray-900 pr-2">{faq.question}</span>
+              <span className="font-medium text-gray-900 pr-2 leading-relaxed">{faq.question}</span>
               <svg
                 className={`flex-shrink-0 w-5 h-5 text-gray-500 transition-transform ${
                   openIndex === index ? 'rotate-180' : ''
@@ -51,10 +51,10 @@ export function FaqAccordion({ faqs }: FaqAccordionProps) {
           {openIndex === index && (
             <div className="px-4 sm:px-6 py-4 bg-gray-50">
               <div className="flex items-start gap-3 sm:gap-4">
-                <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#F39800] rounded-full flex items-center justify-center">
+                <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#F39800] rounded-full flex items-center justify-center mt-0.5">
                   <span className="text-white font-bold text-sm sm:text-base">A</span>
                 </div>
-                <p className="text-gray-700 flex-1">{faq.answer}</p>
+                <p className="text-gray-700 flex-1 leading-relaxed">{faq.answer}</p>
               </div>
             </div>
           )}

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -26,7 +26,7 @@ export function FaqAccordion({ faqs }: FaqAccordionProps) {
             className="w-full px-4 sm:px-6 py-4 text-left flex items-start gap-3 sm:gap-4 hover:bg-gray-50 transition-colors"
             onClick={() => toggleItem(index)}
           >
-            <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#004080] rounded-full flex items-center justify-center mt-0.5">
+            <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#004080] rounded-full flex items-center justify-center mt-1">
               <span className="text-white font-bold text-sm sm:text-base">Q</span>
             </div>
             <div className="flex-1 flex justify-between items-center">
@@ -51,7 +51,7 @@ export function FaqAccordion({ faqs }: FaqAccordionProps) {
           {openIndex === index && (
             <div className="px-4 sm:px-6 py-4 bg-gray-50">
               <div className="flex items-start gap-3 sm:gap-4">
-                <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#F39800] rounded-full flex items-center justify-center mt-0.5">
+                <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#F39800] rounded-full flex items-center justify-center mt-1">
                   <span className="text-white font-bold text-sm sm:text-base">A</span>
                 </div>
                 <p className="text-gray-700 flex-1 leading-relaxed">{faq.answer}</p>

--- a/src/components/FaqAccordion.tsx
+++ b/src/components/FaqAccordion.tsx
@@ -23,14 +23,14 @@ export function FaqAccordion({ faqs }: FaqAccordionProps) {
       {faqs.map((faq, index) => (
         <div key={index} className="border border-gray-200 rounded-lg overflow-hidden">
           <button
-            className="w-full px-4 sm:px-6 py-4 text-left flex items-start gap-3 sm:gap-4 hover:bg-gray-50 transition-colors"
+            className="w-full px-4 sm:px-6 py-4 text-left flex items-center gap-3 sm:gap-4 hover:bg-gray-50 transition-colors"
             onClick={() => toggleItem(index)}
           >
-            <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#004080] rounded-full flex items-center justify-center mt-1">
+            <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#004080] rounded-full flex items-center justify-center">
               <span className="text-white font-bold text-sm sm:text-base">Q</span>
             </div>
             <div className="flex-1 flex justify-between items-center">
-              <span className="font-medium text-gray-900 pr-2 leading-relaxed">{faq.question}</span>
+              <span className="font-medium text-gray-900 pr-2">{faq.question}</span>
               <svg
                 className={`flex-shrink-0 w-5 h-5 text-gray-500 transition-transform ${
                   openIndex === index ? 'rotate-180' : ''
@@ -50,11 +50,11 @@ export function FaqAccordion({ faqs }: FaqAccordionProps) {
           </button>
           {openIndex === index && (
             <div className="px-4 sm:px-6 py-4 bg-gray-50">
-              <div className="flex items-start gap-3 sm:gap-4">
-                <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#F39800] rounded-full flex items-center justify-center mt-1">
+              <div className="flex items-center gap-3 sm:gap-4">
+                <div className="flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 bg-[#F39800] rounded-full flex items-center justify-center">
                   <span className="text-white font-bold text-sm sm:text-base">A</span>
                 </div>
-                <p className="text-gray-700 flex-1 leading-relaxed">{faq.answer}</p>
+                <p className="text-gray-700 flex-1">{faq.answer}</p>
               </div>
             </div>
           )}


### PR DESCRIPTION
- Qアイコン: 青色(#004080)の円形背景に白文字
- Aアイコン: オレンジ色(#F39800)の円形背景に白文字
- レスポンシブ対応（モバイル8x8、デスクトップ10x10）
- 回答部分に薄いグレー背景を追加

🤖 Generated with [Claude Code](https://claude.ai/code)