### PR TITLE
feat: モバイル版の横スクロールUIを改善

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,3 +62,12 @@ body {
   opacity: 1;
   transform: translateY(0);
 }
+
+/* 横スクロールバーを非表示にする */
+.scrollbar-hide {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;  /* Chrome, Safari and Opera */
+}

--- a/src/components/NewsSection.tsx
+++ b/src/components/NewsSection.tsx
@@ -30,7 +30,8 @@ export default function NewsSection({ articles, serviceName }: NewsSectionProps)
       </h2>
       <p className="text-gray-600 mb-6">知っておくと役立つ情報をまとめました</p>
       
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+      {/* デスクトップ: グリッド表示 */}
+      <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-8">
         {articles.slice(0, 6).map((article) => (
           <article key={article._id} className="bg-white rounded-lg shadow-sm overflow-hidden hover:shadow-md transition-shadow h-full">
             {article.thumbnailUrl && (
@@ -75,6 +76,80 @@ export default function NewsSection({ articles, serviceName }: NewsSectionProps)
             </div>
           </article>
         ))}
+      </div>
+
+      {/* モバイル: 横スクロール */}
+      <div className="md:hidden">
+        <div className="relative">
+          {/* スクロールヒント */}
+          <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-gradient-to-l from-gray-50 to-transparent pl-8 pr-2">
+            <div className="bg-white/90 backdrop-blur-sm rounded-full p-2 shadow-md animate-pulse">
+              <svg className="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </div>
+          
+          {/* カードコンテナ */}
+          <div className="flex gap-4 overflow-x-auto pb-4 -mx-4 px-4 snap-x snap-mandatory scrollbar-hide">
+            {articles.map((article) => (
+              <article key={article._id} className="flex-none w-80 snap-start bg-white rounded-lg shadow-sm overflow-hidden">
+                {article.thumbnailUrl && (
+                  <Link href={`/blog/${article.slug}`} className="block">
+                    <div className="relative w-full aspect-[3/2] overflow-hidden bg-gray-100">
+                      <Image
+                        src={article.thumbnailUrl}
+                        alt={article.title}
+                        fill
+                        sizes="320px"
+                        className="object-cover"
+                      />
+                    </div>
+                  </Link>
+                )}
+                <div className="p-4">
+                  <div className="flex items-center space-x-3 mb-3">
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                      {article.category}
+                    </span>
+                    {article.publishedAt && (
+                      <time className="text-xs text-gray-500">
+                        {new Date(article.publishedAt).toLocaleDateString('ja-JP')}
+                      </time>
+                    )}
+                  </div>
+                  <Link href={`/blog/${article.slug}`} className="block">
+                    <h3 className="text-base font-bold text-gray-900 mb-2 line-clamp-2">
+                      {article.title}
+                    </h3>
+                  </Link>
+                  <p className="text-sm text-gray-600 line-clamp-2 mb-3">{article.excerpt}</p>
+                  <Link 
+                    href={`/blog/${article.slug}`}
+                    className="inline-flex items-center text-sm text-blue-600 font-medium"
+                  >
+                    続きを読む
+                    <svg className="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          {/* ドットインジケーター */}
+          {articles.length > 1 && (
+            <div className="flex justify-center mt-4 gap-1">
+              {articles.map((_, index) => (
+                <div
+                  key={index}
+                  className="w-1.5 h-1.5 rounded-full bg-gray-300"
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {articles.length > 6 && (

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -84,7 +84,18 @@ export default function TestimonialsSection({ testimonials, serviceName }: Testi
 
       {/* モバイル: 横スクロール */}
       <div className="md:hidden">
-        <div className="flex gap-4 overflow-x-auto pb-4 -mx-4 px-4 snap-x snap-mandatory">
+        <div className="relative">
+          {/* スクロールヒント */}
+          <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-gradient-to-l from-gray-50 to-transparent pl-8 pr-2">
+            <div className="bg-white/90 backdrop-blur-sm rounded-full p-2 shadow-md animate-pulse">
+              <svg className="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </div>
+          
+          {/* カードコンテナ */}
+          <div className="flex gap-4 overflow-x-auto pb-4 -mx-4 px-4 snap-x snap-mandatory scrollbar-hide">
           {testimonials.map((testimonial) => (
             <div key={testimonial._id} className="flex-none w-80 snap-start bg-white rounded-lg shadow-sm overflow-hidden">
               {/* 写真部分 */}
@@ -131,17 +142,20 @@ export default function TestimonialsSection({ testimonials, serviceName }: Testi
               </div>
             </div>
           ))}
-        </div>
-        {testimonials.length > 1 && (
-          <div className="flex justify-center mt-4 gap-1">
-            {testimonials.map((_, index) => (
-              <div
-                key={index}
-                className="w-2 h-2 rounded-full bg-gray-300"
-              />
-            ))}
           </div>
-        )}
+
+          {/* ドットインジケーター */}
+          {testimonials.length > 1 && (
+            <div className="flex justify-center mt-4 gap-1">
+              {testimonials.map((_, index) => (
+                <div
+                  key={index}
+                  className="w-1.5 h-1.5 rounded-full bg-gray-300"
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {testimonials.length > 3 && (


### PR DESCRIPTION
- お役立ち情報: モバイル版横スクロールを追加
- 両セクションに右側にスクロールヒント（矢印アイコン）を追加
  - 半透明の背景とアニメーション効果
  - スクロール可能であることを視覚的に示す
- ドットインジケーターでカード数を表示
- スクロールバーを非表示にするCSSクラスを追加

🤖 Generated with [Claude Code](https://claude.ai/code)