### PR TITLE
feat: Sanity Studioにカテゴリ別フィルタリング機能を追加

### DIFF
--- a/sanity/deskStructure.ts
+++ b/sanity/deskStructure.ts
@@ -1,0 +1,120 @@
+import {StructureBuilder} from 'sanity/structure'
+
+export const deskStructure = (S: StructureBuilder) =>
+  S.list()
+    .title('コンテンツ')
+    .items([
+      // サービス詳細を展開したメニュー
+      S.listItem()
+        .title('サービス詳細')
+        .child(
+          S.list()
+            .title('サービス詳細')
+            .items([
+              // 全体表示
+              S.listItem()
+                .title('すべてのサービス')
+                .child(
+                  S.documentList()
+                    .title('すべてのサービス')
+                    .filter('_type == "serviceDetail"')
+                    .defaultOrdering([{field: 'parentCategory.orderRank', direction: 'asc'}, {field: 'orderRank', direction: 'asc'}])
+                ),
+              S.divider(),
+              // カテゴリ別表示
+              S.listItem()
+                .title('外国人関連業務')
+                .child(
+                  S.documentList()
+                    .title('外国人関連業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "外国人関連業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('建設・宅地建物取引業関連業務')
+                .child(
+                  S.documentList()
+                    .title('建設・宅地建物取引業関連業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "建設・宅地建物取引業関連業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('自動車関連業務')
+                .child(
+                  S.documentList()
+                    .title('自動車関連業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "自動車関連業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('飲食・風俗営業関連業務')
+                .child(
+                  S.documentList()
+                    .title('飲食・風俗営業関連業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "飲食・風俗営業関連業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('廃棄物処理業許可関連業務')
+                .child(
+                  S.documentList()
+                    .title('廃棄物処理業許可関連業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "廃棄物処理業許可関連業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('旅行・旅館業関連業務')
+                .child(
+                  S.documentList()
+                    .title('旅行・旅館業関連業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "旅行・旅館業関連業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('法人設立業務')
+                .child(
+                  S.documentList()
+                    .title('法人設立業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "法人設立業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('営業許可')
+                .child(
+                  S.documentList()
+                    .title('営業許可')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "営業許可"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('土地関連業務')
+                .child(
+                  S.documentList()
+                    .title('土地関連業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "土地関連業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('権利義務・事実証明業務')
+                .child(
+                  S.documentList()
+                    .title('権利義務・事実証明業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "権利義務・事実証明業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+              S.listItem()
+                .title('その他の業務')
+                .child(
+                  S.documentList()
+                    .title('その他の業務')
+                    .filter('_type == "serviceDetail" && references(*[_type == "serviceCategory" && title == "その他の業務"]._id)')
+                    .defaultOrdering([{field: 'orderRank', direction: 'asc'}])
+                ),
+            ])
+        ),
+      S.divider(),
+      // その他のドキュメントタイプ
+      ...S.documentTypeListItems().filter(
+        (listItem) => !['serviceDetail'].includes(listItem.getId() as string)
+      ),
+    ])

--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -2,6 +2,7 @@ import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
+import {deskStructure} from './deskStructure'
 
 export default defineConfig({
   name: 'default',
@@ -10,7 +11,12 @@ export default defineConfig({
   projectId: 'njgo6ucb',
   dataset: 'production',
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [
+    structureTool({
+      structure: deskStructure,
+    }),
+    visionTool()
+  ],
 
   schema: {
     types: schemaTypes,


### PR DESCRIPTION
- Structure Builderを使用してサービス詳細をカテゴリ別に表示
- 「すべてのサービス」と各カテゴリ別の表示を選択可能
- 12カテゴリすべてに対応したフィルタリングメニュー
- 管理効率の向上を実現

🤖 Generated with [Claude Code](https://claude.ai/code)