### PR TITLE
feat: トップページにサービス検索機能を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import Image from 'next/image';
 import { sanityClient } from '@/lib/sanity.client';
-import { allServiceCategoriesQuery } from '@/lib/queries';
+import { allServiceCategoriesQuery, allServicesForSearchQuery } from '@/lib/queries';
 import Header from '@/components/Header';
 import UnifiedFooter from '@/components/UnifiedFooter';
 import NewCTASection from '@/components/NewCTASection';
 import ScrollAnimationWrapper from '@/components/ScrollAnimationWrapper';
+import ServiceSearch from '@/components/ServiceSearch';
 import { getFeaturedTestimonials, getNews, getBlogs } from '../../lib/sanity';
 
 // ISR設定：60秒ごとに再生成（開発中は短めに設定）
@@ -85,8 +86,25 @@ async function getServiceCategories(): Promise<ServiceCategoryItem[]> {
   }
 }
 
+// Sanityから検索用のサービス一覧を取得
+async function getServicesForSearch() {
+  // 環境変数が設定されていない場合は空配列を返す
+  if (!process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.NEXT_PUBLIC_SANITY_PROJECT_ID === 'dummy-project-id') {
+    return [];
+  }
+  
+  try {
+    const data = await sanityClient.fetch(allServicesForSearchQuery);
+    return data;
+  } catch (error) {
+    console.error('Failed to fetch services for search:', error);
+    return [];
+  }
+}
+
 export default async function Home() {
   const serviceCategories = await getServiceCategories();
+  const servicesForSearch = await getServicesForSearch();
   const featuredTestimonials = await getFeaturedTestimonials(3);
   const newsItems = await getNews();
   // 最新5件のみ取得
@@ -269,6 +287,17 @@ export default async function Home() {
             <h2 className="text-3xl font-bold text-gray-900 mb-4">サービス</h2>
             <div className="w-20 h-1 bg-gray-900 mx-auto mb-4"></div>
             <p className="text-sm text-gray-600 tracking-widest">OUR SERVICES</p>
+          </div>
+          
+          {/* サービス検索 */}
+          <div className="mb-12">
+            <h3 className="text-xl font-semibold text-gray-900 text-center mb-6">サービス名から探す</h3>
+            <ServiceSearch services={servicesForSearch} />
+          </div>
+          
+          {/* カテゴリー一覧 */}
+          <div className="mt-16">
+            <h3 className="text-xl font-semibold text-gray-900 text-center mb-6">カテゴリーから探す</h3>
           </div>
           
           {/* Sanityからのデータがある場合は動的に表示 */}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -70,6 +70,7 @@ export default async function Services() {
           
           {/* サービス検索 */}
           <div className="mb-12">
+            <h2 className="text-2xl font-semibold text-gray-900 text-center mb-8">サービス名から探す</h2>
             <ServiceSearch services={servicesForSearch} />
           </div>
           {/* カテゴリー一覧 */}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -2,12 +2,13 @@ import Header from "@/components/Header";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import PageHeader from "@/components/PageHeader";
 import { sanityClient } from '@/lib/sanity.client';
-import { allServiceCategoriesQuery } from '@/lib/queries';
+import { allServiceCategoriesQuery, allServicesForSearchQuery } from '@/lib/queries';
 import { ServiceCategory } from '@/lib/types';
 import CategoryCard from '@/components/CategoryCard';
 import DebugCategoryCard from '@/components/DebugCategoryCard';
 import NewCTASection from '@/components/NewCTASection';
 import UnifiedFooter from '@/components/UnifiedFooter';
+import ServiceSearch from '@/components/ServiceSearch';
 
 // ISRの設定：1日ごとに再生成
 export const revalidate = 86400;
@@ -28,8 +29,25 @@ async function getServiceCategories(): Promise<ServiceCategory[]> {
   }
 }
 
+// Sanityから検索用のサービス一覧を取得
+async function getServicesForSearch() {
+  // 環境変数が設定されていない場合は空配列を返す
+  if (!process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.NEXT_PUBLIC_SANITY_PROJECT_ID === 'dummy-project-id') {
+    return [];
+  }
+  
+  try {
+    const data = await sanityClient.fetch(allServicesForSearchQuery);
+    return data;
+  } catch (error) {
+    console.error('Failed to fetch services for search:', error);
+    return [];
+  }
+}
+
 export default async function Services() {
   const categories = await getServiceCategories();
+  const servicesForSearch = await getServicesForSearch();
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
@@ -49,6 +67,16 @@ export default async function Services() {
               { name: 'サービス総合案内', href: '/services' }
             ]}
           />
+          
+          {/* サービス検索 */}
+          <div className="mb-12">
+            <ServiceSearch services={servicesForSearch} />
+          </div>
+          {/* カテゴリー一覧 */}
+          <div className="mt-8">
+            <h2 className="text-2xl font-semibold text-gray-900 text-center mb-8">カテゴリーから探す</h2>
+          </div>
+          
           {/* Sanityからのデータがある場合は動的に表示 */}
           {categories.length > 0 ? (
             <>

--- a/src/components/ServiceSearch.tsx
+++ b/src/components/ServiceSearch.tsx
@@ -56,7 +56,7 @@ export default function ServiceSearch({ services }: ServiceSearchProps) {
   }, []);
 
   return (
-    <div className="w-full max-w-2xl mx-auto" ref={searchRef}>
+    <div className="w-full max-w-md mx-auto" ref={searchRef}>
       <div className="relative">
         {/* 検索入力 */}
         <div className="relative">

--- a/src/components/ServiceSearch.tsx
+++ b/src/components/ServiceSearch.tsx
@@ -64,8 +64,8 @@ export default function ServiceSearch({ services }: ServiceSearchProps) {
             type="text"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            placeholder="サービス名を入力（例：建設業許可、ビザ申請）"
-            className="w-full px-4 py-3 pl-12 text-gray-900 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            placeholder="サービス名を入力"
+            className="w-full px-4 py-3 pl-12 text-gray-900 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder:text-sm sm:placeholder:text-base"
           />
           <svg className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -106,8 +106,9 @@ export default function ServiceSearch({ services }: ServiceSearchProps) {
       </div>
 
       {/* 検索ガイダンス */}
-      <p className="mt-2 text-sm text-gray-600 text-center">
-        キーワードの一部を入力すると、関連するサービスが表示されます
+      <p className="mt-2 text-xs sm:text-sm text-gray-600 text-center">
+        <span className="hidden sm:inline">キーワードの一部を入力すると、関連するサービスが表示されます</span>
+        <span className="sm:hidden">例：建設業許可、ビザ申請</span>
       </p>
     </div>
   );

--- a/src/components/ServiceSearch.tsx
+++ b/src/components/ServiceSearch.tsx
@@ -39,7 +39,7 @@ export default function ServiceSearch({ services }: ServiceSearchProps) {
       return false;
     });
 
-    setFilteredServices(results.slice(0, 5)); // 最大5件表示
+    setFilteredServices(results); // 全件表示
     setIsOpen(results.length > 0);
   }, [searchTerm, services]);
 
@@ -74,7 +74,12 @@ export default function ServiceSearch({ services }: ServiceSearchProps) {
 
         {/* 検索結果ドロップダウン */}
         {isOpen && (
-          <div className="absolute z-50 w-full mt-2 bg-white border border-gray-200 rounded-lg shadow-lg">
+          <div className="absolute z-50 w-full mt-2 bg-white border border-gray-200 rounded-lg shadow-lg max-h-96 overflow-y-auto">
+            {filteredServices.length > 0 && (
+              <div className="px-4 py-2 text-sm text-gray-500 border-b border-gray-100">
+                {filteredServices.length}件のサービスが見つかりました
+              </div>
+            )}
             <ul className="py-2">
               {filteredServices.map((service) => (
                 <li key={service._id}>

--- a/src/components/ServiceSearch.tsx
+++ b/src/components/ServiceSearch.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
+// import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+
+interface ServiceItem {
+  _id: string;
+  title: string;
+  slug: string;
+  categorySlug: string;
+  tags?: string[];
+}
+
+interface ServiceSearchProps {
+  services: ServiceItem[];
+}
+
+export default function ServiceSearch({ services }: ServiceSearchProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filteredServices, setFilteredServices] = useState<ServiceItem[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const searchRef = useRef<HTMLDivElement>(null);
+
+  // 検索処理
+  useEffect(() => {
+    if (searchTerm.length === 0) {
+      setFilteredServices([]);
+      setIsOpen(false);
+      return;
+    }
+
+    const results = services.filter(service => {
+      const term = searchTerm.toLowerCase();
+      // タイトルでの検索
+      if (service.title.toLowerCase().includes(term)) return true;
+      // タグでの検索
+      if (service.tags?.some(tag => tag.toLowerCase().includes(term))) return true;
+      return false;
+    });
+
+    setFilteredServices(results.slice(0, 5)); // 最大5件表示
+    setIsOpen(results.length > 0);
+  }, [searchTerm, services]);
+
+  // クリック外で閉じる
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (searchRef.current && !searchRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div className="w-full max-w-2xl mx-auto" ref={searchRef}>
+      <div className="relative">
+        {/* 検索入力 */}
+        <div className="relative">
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="サービス名を入力（例：建設業許可、ビザ申請）"
+            className="w-full px-4 py-3 pl-12 text-gray-900 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+          <svg className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </div>
+
+        {/* 検索結果ドロップダウン */}
+        {isOpen && (
+          <div className="absolute z-50 w-full mt-2 bg-white border border-gray-200 rounded-lg shadow-lg">
+            <ul className="py-2">
+              {filteredServices.map((service) => (
+                <li key={service._id}>
+                  <Link
+                    href={`/services/${service.categorySlug}/${service.slug}`}
+                    onClick={() => {
+                      setSearchTerm('');
+                      setIsOpen(false);
+                    }}
+                    className="block px-4 py-3 hover:bg-gray-50 transition-colors"
+                  >
+                    <div className="font-medium text-gray-900">{service.title}</div>
+                    {service.tags && service.tags.length > 0 && (
+                      <div className="text-sm text-gray-500 mt-1">
+                        {service.tags.slice(0, 3).join('、')}
+                      </div>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {/* 検索ガイダンス */}
+      <p className="mt-2 text-sm text-gray-600 text-center">
+        キーワードの一部を入力すると、関連するサービスが表示されます
+      </p>
+    </div>
+  );
+}

--- a/src/components/ServiceSearch.tsx
+++ b/src/components/ServiceSearch.tsx
@@ -56,7 +56,7 @@ export default function ServiceSearch({ services }: ServiceSearchProps) {
   }, []);
 
   return (
-    <div className="w-full max-w-md mx-auto" ref={searchRef}>
+    <div className="w-full max-w-xl mx-auto" ref={searchRef}>
       <div className="relative">
         {/* 検索入力 */}
         <div className="relative">

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -262,3 +262,14 @@ export const newsByCategoryQuery = `
     "thumbnailUrl": featuredImage.asset->url
   }
 `;
+
+// 16. サービス検索用のクエリ（タイトルとタグ情報を含む）
+export const allServicesForSearchQuery = `
+  *[_type == "serviceDetail"] | order(orderRank asc, _createdAt asc) {
+    _id,
+    title,
+    "slug": slug.current,
+    "categorySlug": parentCategory->slug.current,
+    "tags": tag
+  }
+`;


### PR DESCRIPTION
- ServiceSearchコンポーネントを新規作成
- サービス名とタグによる検索機能を実装
- 検索結果をドロップダウンで表示
- 検索ガイダンステキストを追加
- Sanityクエリを追加（allServicesForSearchQuery）
- トップページのサービスセクションに統合