### PR TITLE
feat: カテゴリーセクションのUX改善

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -297,7 +297,8 @@ export default async function Home() {
           
           {/* カテゴリー一覧 */}
           <div className="mt-16">
-            <h3 className="text-xl font-semibold text-gray-900 text-center mb-6">カテゴリーから探す</h3>
+            <h3 className="text-xl font-semibold text-gray-900 text-center mb-2">カテゴリーから探す</h3>
+            <p className="text-base text-gray-600 text-center mb-6">業種や目的からお探しください</p>
           </div>
           
           {/* Sanityからのデータがある場合は動的に表示 */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -531,7 +531,7 @@ export default async function Home() {
               href="/services" 
               className="inline-flex items-center justify-center w-full sm:w-auto px-6 py-3 border border-blue-600 text-blue-600 font-semibold rounded-lg hover:bg-blue-50 transition-colors"
             >
-              サービス詳細を見る
+              もっと詳しく見る
             </Link>
           </div>
         </div>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -75,7 +75,8 @@ export default async function Services() {
           </div>
           {/* カテゴリー一覧 */}
           <div className="mt-8">
-            <h2 className="text-2xl font-semibold text-gray-900 text-center mb-8">カテゴリーから探す</h2>
+            <h2 className="text-2xl font-semibold text-gray-900 text-center mb-4">カテゴリーから探す</h2>
+            <p className="text-base text-gray-600 text-center mb-8">業種や目的からお探しください</p>
           </div>
           
           {/* Sanityからのデータがある場合は動的に表示 */}

--- a/src/components/NewCTASection.tsx
+++ b/src/components/NewCTASection.tsx
@@ -77,7 +77,7 @@ export default function NewCTASection({ serviceName }: NewCTASectionProps) {
               href="/services"
               className="bg-white text-blue-600 border border-blue-600 px-6 sm:px-8 py-3 rounded-lg font-semibold hover:bg-blue-50 transition-colors shadow-lg text-center w-full sm:w-auto"
             >
-              サービス詳細
+              もっと詳しく見る
             </Link>
           </div>
         </div>

--- a/src/components/NewCTASection.tsx
+++ b/src/components/NewCTASection.tsx
@@ -77,7 +77,7 @@ export default function NewCTASection({ serviceName }: NewCTASectionProps) {
               href="/services"
               className="bg-white text-blue-600 border border-blue-600 px-6 sm:px-8 py-3 rounded-lg font-semibold hover:bg-blue-50 transition-colors shadow-lg text-center w-full sm:w-auto"
             >
-              もっと詳しく見る
+              サービス詳細
             </Link>
           </div>
         </div>


### PR DESCRIPTION
- カテゴリーから探すセクションに説明文「業種や目的からお探しください」を追加
- CTAボタンのテキストを「サービス詳細」から「もっと詳しく見る」に変更

🤖 Generated with [Claude Code](https://claude.ai/code)