### PR TITLE
feat: 特徴ページのQAセクションをSanity対応に変更

### DIFF
--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -6,5 +6,6 @@ import serviceDetail from './serviceDetail'
 import contact from '../schemas/contact'
 import staff from './staff'
 import { tableBlock } from './customBlocks/tableBlock'
+import featuresFaq from '../schemas/featuresFaq'
 
-export const schemaTypes = [news, testimonials, blog, serviceCategory, serviceDetail, contact, staff, tableBlock]
+export const schemaTypes = [news, testimonials, blog, serviceCategory, serviceDetail, contact, staff, tableBlock, featuresFaq]

--- a/sanity/schemas/featuresFaq.ts
+++ b/sanity/schemas/featuresFaq.ts
@@ -51,7 +51,6 @@ export default defineType({
       return {
         title: `${order}. ${title}`,
         subtitle: subtitle ? subtitle.substring(0, 100) + '...' : '',
-        media: isPublished ? '✅' : '🚫',
       }
     },
   },

--- a/sanity/schemas/featuresFaq.ts
+++ b/sanity/schemas/featuresFaq.ts
@@ -1,0 +1,58 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'featuresFaq',
+  title: '特徴ページのよくある質問',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'question',
+      title: '質問',
+      type: 'string',
+      validation: (Rule) => Rule.required().error('質問は必須です'),
+    }),
+    defineField({
+      name: 'answer',
+      title: '回答',
+      type: 'text',
+      rows: 4,
+      validation: (Rule) => Rule.required().error('回答は必須です'),
+    }),
+    defineField({
+      name: 'order',
+      title: '表示順',
+      type: 'number',
+      initialValue: 0,
+      validation: (Rule) => Rule.required().min(0).error('表示順は0以上の数値を入力してください'),
+    }),
+    defineField({
+      name: 'isPublished',
+      title: '公開',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  orderings: [
+    {
+      title: '表示順',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'question',
+      subtitle: 'answer',
+      order: 'order',
+      isPublished: 'isPublished',
+    },
+    prepare(selection) {
+      const { title, subtitle, order, isPublished } = selection
+      return {
+        title: `${order}. ${title}`,
+        subtitle: subtitle ? subtitle.substring(0, 100) + '...' : '',
+        media: isPublished ? '✅' : '🚫',
+      }
+    },
+  },
+})

--- a/src/app/api/features-faq/route.ts
+++ b/src/app/api/features-faq/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { sanityClient } from '@/lib/sanity'
+import { sanityClient } from '@/lib/sanity.client'
 
 export async function GET() {
   try {

--- a/src/app/api/features-faq/route.ts
+++ b/src/app/api/features-faq/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { sanityClient } from '@/lib/sanity'
+
+export async function GET() {
+  try {
+    const query = `*[_type == "featuresFaq" && isPublished == true] | order(order asc) {
+      _id,
+      question,
+      answer,
+      order
+    }`
+
+    const faqs = await sanityClient.fetch(query)
+
+    return NextResponse.json(faqs)
+  } catch (error) {
+    console.error('Error fetching features FAQs:', error)
+    return NextResponse.json({ error: 'Failed to fetch FAQs' }, { status: 500 })
+  }
+}

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -5,13 +5,35 @@ import UnifiedFooter from '@/components/UnifiedFooter';
 import NewCTASection from '@/components/NewCTASection';
 import PageHeader from '@/components/PageHeader';
 import Link from 'next/link';
+import { FaqAccordion } from '@/components/FaqAccordion';
+import { FaqItem } from '@/lib/types';
 
 export const metadata: Metadata = {
   title: '当事務所の特徴 | フォルティア行政書士事務所',
   description: 'フォルティア行政書士事務所の特徴をご紹介します。豊富な実績と専門知識で、お客様のニーズにお応えします。',
 };
 
-export default function FeaturesPage() {
+async function getFeaturesFAQ(): Promise<FaqItem[]> {
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/features-faq`, {
+      next: { revalidate: 60 } // 1分間キャッシュ
+    });
+    
+    if (!response.ok) {
+      console.error('Failed to fetch FAQs');
+      return [];
+    }
+    
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching FAQs:', error);
+    return [];
+  }
+}
+
+export default async function FeaturesPage() {
+  const faqs = await getFeaturesFAQ();
+  
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
@@ -258,19 +280,13 @@ export default function FeaturesPage() {
             </h3>
           </div>
 
-          <div className="space-y-8">
-            {[1, 2, 3, 4, 5].map(num => (
-              <div key={num} className="border-b pb-6">
-                <h4 className="text-lg font-semibold mb-3">
-                  Q{num}. ○○○○は○○○○ですか？
-                </h4>
-                <p className="text-gray-600 leading-relaxed">
-                  そんなことはありません。私たちでは○○を用意して、○○しているから、○○のようなお答さまにも安心してお使い<br />
-                  いただけます。そんなことはありません。私たちでは○○を用意して、○○しているから、○○のようなお答さまにも
-                </p>
-              </div>
-            ))}
-          </div>
+          {faqs.length > 0 ? (
+            <FaqAccordion faqs={faqs} />
+          ) : (
+            <div className="text-center py-8 text-gray-500">
+              現在、よくある質問を準備中です。
+            </div>
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
- featuresFAQスキーマを作成
- APIエンドポイント /api/features-faq を追加
- 特徴ページでFaqAccordionコンポーネントを使用
- サービス詳細ページと同じデザインに統一

🤖 Generated with [Claude Code](https://claude.ai/code)