### PR TITLE
fix: サービス総合案内ページの正しいカードデザインを復元

### DIFF
--- a/src/app/[lang]/services/page.tsx
+++ b/src/app/[lang]/services/page.tsx
@@ -80,21 +80,49 @@ export default async function Services({ params }: PageProps) {
             </>
           ) : (
             /* 多言語対応のハードコーディングされたサービスを表示 */
-            <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
               {servicesContent[lang].categories.map((category) => (
-                <Link 
-                  key={category.id}
-                  href={`${basePath}/services/${category.slug}`} 
-                  className="bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow text-center block"
-                >
-                  <div className={`w-12 h-12 ${category.colorClass.bg} rounded-full flex items-center justify-center mx-auto mb-4`}>
-                    <svg className={`w-6 h-6 ${category.colorClass.text}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={category.icon} />
-                    </svg>
-                  </div>
-                  <h3 className="text-lg font-semibold text-gray-900 mb-2">{category.title}</h3>
-                  <p className="text-sm text-gray-600">{category.description}</p>
-                </Link>
+                <div key={category.id} className="h-full">
+                  <Link
+                    href={`${basePath}/services/${category.slug}`}
+                    className="block bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 h-full"
+                  >
+                    {/* カテゴリー画像 */}
+                    <div className={`relative h-48 rounded-t-xl overflow-hidden ${category.colorClass.bg} flex items-center justify-center`}>
+                      <svg className={`w-16 h-16 ${category.colorClass.text}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={category.icon} />
+                      </svg>
+                    </div>
+
+                    {/* カテゴリー情報 */}
+                    <div className="p-6 flex flex-col h-[calc(100%-12rem)]">
+                      <div className="flex-grow">
+                        <h3 className="text-xl font-bold text-gray-900 mb-2">{category.title}</h3>
+                        <p className="text-gray-600 text-sm mb-4">{category.description}</p>
+                      </div>
+
+                      {/* サービス例（後で追加予定） */}
+                      <div className="mt-auto">
+                        <div className="mb-4">
+                          <p className="text-xs text-gray-500 font-medium mb-2">
+                            {lang === 'ja' ? 'サービス例' : 'Service Examples'}
+                          </p>
+                          <p className="text-sm text-gray-600">
+                            {lang === 'ja' ? '詳細は各ページをご確認ください' : 'Please check each page for details'}
+                          </p>
+                        </div>
+
+                        {/* 詳しく見るボタン */}
+                        <div className="flex items-center justify-end text-[#004080] hover:text-[#003366] font-medium">
+                          <span>{lang === 'ja' ? '詳しく見る' : 'Learn More'}</span>
+                          <svg className="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                </div>
               ))}
             </div>
           )}


### PR DESCRIPTION
- ハードコードサービスカードを詳細表示形式に修正
- 元のCategoryCard相当のレイアウトとスタイルを適用
- 画像、タイトル、説明、「詳しく見る」ボタンを含む構造に変更
- Sanityデータとハードコードデータで一貫したデザインを実現

🤖 Generated with [Claude Code](https://claude.ai/code)