### PR TITLE
test: 外国人関連業務の第3階層をハードコード化テスト

### DIFF
--- a/src/app/[lang]/services/[category]/page.tsx
+++ b/src/app/[lang]/services/[category]/page.tsx
@@ -92,10 +92,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function CategoryPage({ params }: Props) {
   const { category, lang } = await params;
   
-  // ハードコーディングデータをまずチェック
-  const hardcodedData = categoryPagesContent[lang]?.[category];
-  
-  if (hardcodedData) {
+  // テスト：外国人関連業務のみハードコード、他はSanityフォールバック
+  if (category === 'foreign') {
+    // 外国人関連業務：完全ハードコード表示
+    const hardcodedData = categoryPagesContent[lang]?.[category];
+    
+    if (!hardcodedData) {
+      notFound();
+    }
     // ハードコーディングデータを使用
     const serviceStructuredData = {
       '@context': 'https://schema.org',
@@ -260,7 +264,7 @@ export default async function CategoryPage({ params }: Props) {
     );
   }
 
-  // Sanityフォールバック
+  // 他のカテゴリー：Sanityフォールバック（比較用）
   if (!process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || process.env.NEXT_PUBLIC_SANITY_PROJECT_ID === 'dummy-project-id') {
     notFound();
   }


### PR DESCRIPTION
- category === 'foreign' の場合のみハードコードデータを使用
- 他のカテゴリーはSanityフォールバックのまま（比較用）
- 第2階層と同じアプローチで実装
- 日本語・英語の多言語対応済み