### PR TITLE
feat: ホームページデザイン更新完了

### DIFF
--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -187,12 +187,11 @@ export default async function Home({ params }: PageProps) {
 
       {/* ヒーローセクション */}
       <section className="relative text-white min-h-screen flex items-center bg-cover bg-center bg-no-repeat" style={{backgroundImage: "url('/hero-background2.png')"}}>
-        <div className="absolute inset-0 bg-black bg-opacity-30"></div>
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full z-10">
           <div className="text-left">
             <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-6 sm:mb-8">
-              <span className="text-white block mb-2">{t.hero.title1}</span>
-              <span className="text-white block">{t.hero.title2}</span>
+              <span className="text-white block mb-2 drop-shadow-lg">{t.hero.title1}</span>
+              <span className="text-white block drop-shadow-lg">{t.hero.title2}</span>
             </h1>
             <div className="mt-8 sm:mt-12 flex flex-col sm:flex-row gap-4 items-start">
               <Link 
@@ -206,7 +205,7 @@ export default async function Home({ params }: PageProps) {
               </Link>
               <Link 
                 href={`${basePath}/services`}
-                className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-transparent rounded-lg hover:bg-white hover:text-gray-900 transition-all duration-200 border-2 border-white"
+                className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-transparent rounded-lg hover:bg-white hover:text-gray-900 transition-all duration-200 border-2 border-white shadow-lg"
               >
                 {t.hero.viewServices}
               </Link>
@@ -329,7 +328,7 @@ export default async function Home({ params }: PageProps) {
           
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
             <ScrollAnimationWrapper delay={0}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/foreign-resident.png"
@@ -340,7 +339,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '外国人関連業務' : 'Foreign Resident Services'}
               </h3>
@@ -349,7 +348,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.1}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/construction-realestate.png"
@@ -360,7 +359,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '建設・宅建業関連' : 'Construction & Real Estate'}
               </h3>
@@ -369,7 +368,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.2}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/automotive.png"
@@ -380,7 +379,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '自動車関連業務' : 'Automotive Services'}
               </h3>
@@ -389,7 +388,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.3}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/restaurant-entertainment.png"
@@ -400,7 +399,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '飲食・風俗営業関連業務' : 'Restaurant & Entertainment Business'}
               </h3>
@@ -409,7 +408,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.4}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/waste-management.png"
@@ -420,7 +419,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '廃棄物処理業許可関連業務' : 'Waste Management Permits'}
               </h3>
@@ -429,7 +428,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.5}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/travel-hotel.png"
@@ -440,7 +439,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '旅行・旅館業関連業務' : 'Travel & Hotel Business'}
               </h3>
@@ -449,7 +448,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.6}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/corporate-establishment.png"
@@ -460,7 +459,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '法人設立業務' : 'Corporate Establishment'}
               </h3>
@@ -469,7 +468,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.7}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/business-license.png"
@@ -480,7 +479,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '営業許可' : 'Business Licenses'}
               </h3>
@@ -489,7 +488,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.8}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/land-services.png"
@@ -500,7 +499,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '土地関連業務' : 'Land-related Services'}
               </h3>
@@ -509,7 +508,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={0.9}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/rights-documentation.png"
@@ -520,7 +519,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '権利義務・事実証明業務' : 'Rights & Legal Documentation'}
               </h3>
@@ -529,7 +528,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={1.0}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/medical-care.png"
@@ -540,7 +539,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? '医療・介護関連業務' : 'Medical & Care Services'}
               </h3>
@@ -549,7 +548,7 @@ export default async function Home({ params }: PageProps) {
             </ScrollAnimationWrapper>
 
             <ScrollAnimationWrapper delay={1.1}>
-              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 flex items-center justify-center sm:flex-col text-center">
+              <div className="bg-white p-4 sm:p-6 rounded-lg shadow-sm hover:shadow-md md:hover:scale-105 hover:bg-blue-100/70 transition-all duration-300 h-full flex flex-col items-center justify-center text-center">
               <div className="w-16 sm:w-20 md:w-[108px] h-16 sm:h-20 md:h-[108px] mb-2 sm:mb-4">
                 <Image
                   src="/service-icons/other-services.png"
@@ -560,7 +559,7 @@ export default async function Home({ params }: PageProps) {
                   unoptimized
                 />
               </div>
-              <div>
+              <div className="flex-1 flex items-center">
               <h3 className="text-base sm:text-base md:text-lg font-semibold text-gray-900">
                 {lang === 'ja' ? 'その他の業務' : 'Other Services'}
               </h3>

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -186,12 +186,13 @@ export default async function Home({ params }: PageProps) {
       <Header lang={lang} />
 
       {/* ヒーローセクション */}
-      <section className="relative text-gray-900 min-h-screen flex items-center bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
+      <section className="relative text-white min-h-screen flex items-center bg-cover bg-center bg-no-repeat" style={{backgroundImage: "url('/hero-background2.png')"}}>
+        <div className="absolute inset-0 bg-black bg-opacity-30"></div>
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full z-10">
           <div className="text-left">
             <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-6 sm:mb-8">
-              <span className="text-blue-600 block mb-2">{t.hero.title1}</span>
-              <span className="text-blue-600 block">{t.hero.title2}</span>
+              <span className="text-white block mb-2">{t.hero.title1}</span>
+              <span className="text-white block">{t.hero.title2}</span>
             </h1>
             <div className="mt-8 sm:mt-12 flex flex-col sm:flex-row gap-4 items-start">
               <Link 
@@ -205,7 +206,7 @@ export default async function Home({ params }: PageProps) {
               </Link>
               <Link 
                 href={`${basePath}/services`}
-                className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-blue-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors border-2 border-gray-300"
+                className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-transparent rounded-lg hover:bg-white hover:text-gray-900 transition-all duration-200 border-2 border-white"
               >
                 {t.hero.viewServices}
               </Link>
@@ -241,8 +242,8 @@ export default async function Home({ params }: PageProps) {
                   <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.achievement.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4 mt-auto">
-                    <div className="flex justify-around text-center">
+                  <div className="bg-blue-50 rounded-lg p-4 mt-auto min-h-[88px] flex items-center">
+                    <div className="flex justify-around text-center w-full">
                       <div>
                         <p className="text-2xl font-bold text-blue-600">10,000+</p>
                         <p className="text-sm text-gray-500 mt-1">{t.features.achievement.applications}</p>
@@ -275,7 +276,7 @@ export default async function Home({ params }: PageProps) {
                   <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.pricing.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4 text-center mt-auto">
+                  <div className="bg-blue-50 rounded-lg p-4 text-center mt-auto min-h-[88px] flex flex-col justify-center">
                     <p className="text-blue-900 font-bold text-lg">{t.features.pricing.savings}</p>
                     <p className="text-blue-700 text-sm mt-1">{t.features.pricing.comparison}</p>
                   </div>
@@ -301,8 +302,8 @@ export default async function Home({ params }: PageProps) {
                   <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.multilingual.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4 mt-auto">
-                    <div className="flex flex-wrap gap-2 justify-center">
+                  <div className="bg-blue-50 rounded-lg p-4 mt-auto min-h-[88px] flex items-center">
+                    <div className="flex flex-wrap gap-2 justify-center w-full">
                       {languages[lang].map((language, index) => (
                         <span key={index} className="px-3 py-1 bg-white text-blue-700 rounded-full text-sm font-medium border border-blue-200">
                           {language}
@@ -666,7 +667,7 @@ export default async function Home({ params }: PageProps) {
       </section>
 
       <NewCTASection lang={lang} />
-      <UnifiedFooter />
+      <UnifiedFooter lang={lang} />
     </div>
   );
 }

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -186,29 +186,30 @@ export default async function Home({ params }: PageProps) {
       <Header lang={lang} />
 
       {/* ヒーローセクション */}
-      <section className="relative text-white min-h-screen flex items-center bg-cover bg-center bg-no-repeat" style={{backgroundImage: "url('/hero-background2.png')"}}>
-        <div className="absolute inset-0 bg-black bg-opacity-50"></div>
-        <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-6 sm:mb-8">
-            <span className="text-blue-400 block mb-2">{t.hero.title1}</span>
-            <span className="text-blue-400 block">{t.hero.title2}</span>
-          </h1>
-          <div className="mt-8 sm:mt-12 flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <Link 
-              href={`${basePath}/contact`}
-              className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transform hover:scale-105 transition-all duration-200 shadow-lg"
-            >
-              {t.hero.freeConsultation}
-              <svg className="ml-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
-            <Link 
-              href={`${basePath}/services`}
-              className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-blue-600 bg-white rounded-lg hover:bg-blue-50 transition-colors border-2 border-white"
-            >
-              {t.hero.viewServices}
-            </Link>
+      <section className="relative text-gray-900 min-h-screen flex items-center bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
+          <div className="text-left">
+            <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-6 sm:mb-8">
+              <span className="text-blue-600 block mb-2">{t.hero.title1}</span>
+              <span className="text-blue-600 block">{t.hero.title2}</span>
+            </h1>
+            <div className="mt-8 sm:mt-12 flex flex-col sm:flex-row gap-4 items-start">
+              <Link 
+                href={`${basePath}/contact`}
+                className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transform hover:scale-105 transition-all duration-200 shadow-lg"
+              >
+                {t.hero.freeConsultation}
+                <svg className="ml-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+              <Link 
+                href={`${basePath}/services`}
+                className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-blue-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors border-2 border-gray-300"
+              >
+                {t.hero.viewServices}
+              </Link>
+            </div>
           </div>
         </div>
       </section>
@@ -224,7 +225,7 @@ export default async function Home({ params }: PageProps) {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {/* 申請実績 */}
             <ScrollAnimationWrapper delay={0}>
-              <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 border border-gray-100">
+              <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 border border-gray-100 h-full flex flex-col">
                 <div className="w-full h-48">
                   <Image
                     src="/申請実績1,000件超の信頼.png"
@@ -235,12 +236,12 @@ export default async function Home({ params }: PageProps) {
                     unoptimized
                   />
                 </div>
-                <div className="p-6">
+                <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.achievement.title}</h3>
-                  <p className="text-gray-600 mb-6 leading-relaxed">
+                  <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.achievement.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4">
+                  <div className="bg-blue-50 rounded-lg p-4 mt-auto">
                     <div className="flex justify-around text-center">
                       <div>
                         <p className="text-2xl font-bold text-blue-600">10,000+</p>
@@ -258,7 +259,7 @@ export default async function Home({ params }: PageProps) {
 
             {/* 料金設定 */}
             <ScrollAnimationWrapper delay={0.2}>
-              <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 border border-gray-100">
+              <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 border border-gray-100 h-full flex flex-col">
                 <div className="w-full h-48">
                   <Image
                     src="/完全成果報酬制で明朗な料金体系.png"
@@ -269,12 +270,12 @@ export default async function Home({ params }: PageProps) {
                     unoptimized
                   />
                 </div>
-                <div className="p-6">
+                <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.pricing.title}</h3>
-                  <p className="text-gray-600 mb-6 leading-relaxed">
+                  <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.pricing.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4 text-center">
+                  <div className="bg-blue-50 rounded-lg p-4 text-center mt-auto">
                     <p className="text-blue-900 font-bold text-lg">{t.features.pricing.savings}</p>
                     <p className="text-blue-700 text-sm mt-1">{t.features.pricing.comparison}</p>
                   </div>
@@ -284,7 +285,7 @@ export default async function Home({ params }: PageProps) {
 
             {/* 多言語対応 */}
             <ScrollAnimationWrapper delay={0.4}>
-              <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 border border-gray-100">
+              <div className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 border border-gray-100 h-full flex flex-col">
                 <div className="w-full h-48">
                   <Image
                     src="/母国語対応で安心サポート.png"
@@ -295,12 +296,12 @@ export default async function Home({ params }: PageProps) {
                     unoptimized
                   />
                 </div>
-                <div className="p-6">
+                <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.multilingual.title}</h3>
-                  <p className="text-gray-600 mb-6 leading-relaxed">
+                  <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.multilingual.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4">
+                  <div className="bg-blue-50 rounded-lg p-4 mt-auto">
                     <div className="flex flex-wrap gap-2 justify-center">
                       {languages[lang].map((language, index) => (
                         <span key={index} className="px-3 py-1 bg-white text-blue-700 rounded-full text-sm font-medium border border-blue-200">
@@ -617,28 +618,28 @@ export default async function Home({ params }: PageProps) {
           </div>
           {latestNews.length > 0 ? (
             <ScrollAnimationWrapper delay={0}>
-              <div className="max-w-4xl mx-auto">
-                <ul className="space-y-4">
+              <div className="max-w-6xl mx-auto">
+                <ul className="space-y-3">
                   {latestNews.map((news: NewsItem) => (
-                    <li key={news._id} className="border-b border-gray-200 pb-4 last:border-b-0">
+                    <li key={news._id} className="border-b border-gray-200 pb-3 last:border-b-0">
                       <Link
                         href={`${basePath}/news/${news.slug.current}`}
-                        className="block hover:bg-white p-4 rounded-lg transition-colors"
+                        className="block hover:bg-gray-50 p-3 rounded-lg transition-colors"
                       >
-                        <div className="flex items-start justify-between">
-                          <div className="flex-1">
-                            <time className="text-sm text-gray-500 block mb-2">
-                              {new Date(news.publishedAt).toLocaleDateString(lang === 'ja' ? 'ja-JP' : 'en-US')}
-                            </time>
+                        <div className="flex items-center gap-4 md:gap-6">
+                          <time className="text-sm text-gray-500 whitespace-nowrap flex-shrink-0 w-24">
+                            {new Date(news.publishedAt).toLocaleDateString(lang === 'ja' ? 'ja-JP' : 'en-US')}
+                          </time>
+                          <div className="flex-shrink-0">
                             {news.category && categoryMap[news.category] && (
-                              <span className={`inline-block px-2 py-1 rounded text-xs font-medium mb-2 ${categoryMap[news.category][lang].color}`}>
+                              <span className={`inline-block px-2 py-1 rounded text-xs font-medium ${categoryMap[news.category][lang].color}`}>
                                 {categoryMap[news.category][lang].name}
                               </span>
                             )}
-                            <h3 className="text-lg font-medium text-gray-900 hover:text-blue-600 transition-colors line-clamp-2">
-                              {news.title}
-                            </h3>
                           </div>
+                          <h3 className="text-base font-medium text-gray-900 hover:text-blue-600 transition-colors flex-1 line-clamp-1">
+                            {news.title}
+                          </h3>
                         </div>
                       </Link>
                     </li>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { Locale } from '@/lib/i18n/types'
 import { localeNames } from '@/lib/i18n/constants'
@@ -10,6 +11,7 @@ interface LanguageSwitcherProps {
 }
 
 export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps) {
+  const [isOpen, setIsOpen] = useState(false)
   const pathname = usePathname()
   const router = useRouter()
 
@@ -17,32 +19,47 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
     const pathWithoutLocale = getPathWithoutLocale(pathname)
     const newPath = getLocalizedPath(pathWithoutLocale, newLang)
     router.push(newPath)
+    setIsOpen(false)
   }
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="relative">
       <button
-        onClick={() => handleLanguageChange('ja')}
-        className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
-          currentLang === 'ja'
-            ? 'bg-blue-600 text-white'
-            : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-        }`}
-        aria-label="日本語に切り替え"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-3 py-2 text-gray-600 hover:text-gray-900 transition-colors"
+        aria-label="言語を選択"
       >
-        {localeNames.ja}
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 0 1 1.964 1.69l.393 2.36a2 2 0 0 0 1.962 1.95h.838c.632 0 1.253-.17 1.8-.476a2 2 0 0 0 1.035-1.35l.5-3a2 2 0 0 1 1.962-1.677h.838A2 2 0 0 0 17 8.99V7a2 2 0 0 0-2-2h-3.5a2 2 0 0 0-1.732 1H8a2 2 0 0 0-2 2v.09a2 2 0 0 1-.764 1.578L3.055 11z" />
+        </svg>
+        <span className="text-sm font-medium">LANGUAGE</span>
+        <svg className={`w-4 h-4 transform transition-transform ${isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
       </button>
-      <button
-        onClick={() => handleLanguageChange('en')}
-        className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
-          currentLang === 'en'
-            ? 'bg-blue-600 text-white'
-            : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-        }`}
-        aria-label="Switch to English"
-      >
-        {localeNames.en}
-      </button>
+      
+      {isOpen && (
+        <div className="absolute right-0 mt-1 w-32 bg-white border border-gray-200 rounded-md shadow-lg z-50">
+          <div className="py-1">
+            <button
+              onClick={() => handleLanguageChange('ja')}
+              className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 transition-colors ${
+                currentLang === 'ja' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-700'
+              }`}
+            >
+              日本語
+            </button>
+            <button
+              onClick={() => handleLanguageChange('en')}
+              className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 transition-colors ${
+                currentLang === 'en' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-700'
+              }`}
+            >
+              English
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -41,20 +41,20 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
         <div className="absolute right-0 mt-1 w-32 bg-white border border-gray-200 rounded-md shadow-lg z-50">
           <div className="py-1">
             <button
-              onClick={() => handleLanguageChange('ja')}
-              className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 transition-colors ${
-                currentLang === 'ja' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-700'
-              }`}
-            >
-              日本語
-            </button>
-            <button
               onClick={() => handleLanguageChange('en')}
               className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 transition-colors ${
                 currentLang === 'en' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-700'
               }`}
             >
               English
+            </button>
+            <button
+              onClick={() => handleLanguageChange('ja')}
+              className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 transition-colors ${
+                currentLang === 'ja' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-700'
+              }`}
+            >
+              日本語
             </button>
           </div>
         </div>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { Locale } from '@/lib/i18n/types'
-import { localeNames } from '@/lib/i18n/constants'
 import { getLocalizedPath, getPathWithoutLocale } from '@/lib/i18n/utils'
 
 interface LanguageSwitcherProps {

--- a/src/components/UnifiedFooter.tsx
+++ b/src/components/UnifiedFooter.tsx
@@ -2,48 +2,48 @@ import Link from "next/link";
 import { servicesContent } from '@/data/services-content';
 
 export default function UnifiedFooter() {
-  // ハードコーディングされたサービスカテゴリを使用 - Sanity依存なし
+  // Use English service categories
   const serviceCategories = servicesContent.ja.categories;
 
   return (
     <footer className="bg-gray-800 text-white py-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-          {/* 第1列: 事務所情報 */}
+          {/* Column 1: Office Information */}
           <div>
             <Link href="/">
               <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">
-                <span className="text-white">フォルティア</span>
-                <span className="text-white ml-1">行政書士事務所</span>
+                <span className="text-white">Fortia</span>
+                <span className="text-white ml-1">Administrative Law Office</span>
               </h3>
             </Link>
             <div className="mb-4">
               <p className="text-gray-400">
                 〒100-0001<br />
-                東京都千代田区千代田1-1-1<br />
+                1-1-1 Chiyoda, Chiyoda-ku, Tokyo<br />
                 TEL: 03-1234-5678
               </p>
             </div>
             <div className="mb-4">
-              <h4 className="text-sm font-semibold mb-2">営業時間</h4>
+              <h4 className="text-sm font-semibold mb-2">Business Hours</h4>
               <p className="text-gray-400 text-sm">
-                平日: 9:00 - 18:00<br />
-                土曜: 9:00 - 17:00<br />
-                日祝: 休業
+                Weekdays: 9:00 - 18:00<br />
+                Saturday: 9:00 - 17:00<br />
+                Sunday & Holidays: Closed
               </p>
             </div>
             <div>
-              <h4 className="text-sm font-semibold mb-2">主要業務エリア</h4>
+              <h4 className="text-sm font-semibold mb-2">Service Areas</h4>
               <p className="text-gray-400 text-sm">
-                東京都、千葉県、埼玉県、神奈川県<br />
-                ※その他地域もご相談ください
+                Tokyo, Chiba, Saitama, Kanagawa<br />
+                ※Other areas available upon consultation
               </p>
             </div>
           </div>
 
-          {/* 第2列: サービス */}
+          {/* Column 2: Services */}
           <div className="md:col-span-2">
-            <h3 className="text-lg font-semibold mb-4">サービス</h3>
+            <h3 className="text-lg font-semibold mb-4">Services</h3>
             <div className="md:columns-2 md:gap-x-6 space-y-2">
               {serviceCategories.map((category) => (
                 <div key={category.id} className="mb-2 break-inside-avoid">
@@ -58,30 +58,30 @@ export default function UnifiedFooter() {
             </div>
           </div>
 
-          {/* 第3列: その他のリンク */}
+          {/* Column 3: Other Links */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">その他</h3>
+            <h3 className="text-lg font-semibold mb-4">About</h3>
             <ul className="space-y-2">
               <li>
                 <Link href="/about" className="text-gray-400 hover:text-white transition-colors">
-                  事務所案内
+                  About Us
                 </Link>
               </li>
               <li>
                 <Link href="/news" className="text-gray-400 hover:text-white transition-colors">
-                  お知らせ
+                  News
                 </Link>
               </li>
               <li>
                 <Link href="/contact" className="text-gray-400 hover:text-white transition-colors">
-                  お問い合わせ
+                  Contact
                 </Link>
               </li>
             </ul>
           </div>
         </div>
         <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-          <p>&copy; 2024 フォルティア行政書士事務所. All rights reserved.</p>
+          <p>&copy; 2024 Fortia Administrative Law Office. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/src/components/UnifiedFooter.tsx
+++ b/src/components/UnifiedFooter.tsx
@@ -1,9 +1,52 @@
 import Link from "next/link";
 import { servicesContent } from '@/data/services-content';
+import { Locale } from '@/lib/i18n/types';
 
-export default function UnifiedFooter() {
-  // Use English service categories
+interface UnifiedFooterProps {
+  lang?: Locale;
+}
+
+export default function UnifiedFooter({ lang = 'ja' }: UnifiedFooterProps) {
   const serviceCategories = servicesContent.ja.categories;
+  
+  const content = {
+    ja: {
+      companyName: "フォルティア",
+      companyNameFull: "行政書士事務所",
+      businessHours: "営業時間",
+      weekdays: "平日: 9:00 - 18:00",
+      saturday: "土曜: 9:00 - 17:00",
+      holiday: "日祝: 休業",
+      serviceAreas: "主要業務エリア",
+      areasText: "東京都、千葉県、埼玉県、神奈川県",
+      otherAreas: "※その他地域もご相談ください",
+      services: "サービス",
+      about: "その他",
+      aboutUs: "事務所案内",
+      news: "お知らせ",
+      contact: "お問い合わせ",
+      copyright: "© 2024 フォルティア行政書士事務所. All rights reserved."
+    },
+    en: {
+      companyName: "Fortia",
+      companyNameFull: "Administrative Law Office",
+      businessHours: "Business Hours",
+      weekdays: "Weekdays: 9:00 - 18:00",
+      saturday: "Saturday: 9:00 - 17:00",
+      holiday: "Sunday & Holidays: Closed",
+      serviceAreas: "Service Areas",
+      areasText: "Tokyo, Chiba, Saitama, Kanagawa",
+      otherAreas: "※Other areas available upon consultation",
+      services: "Services",
+      about: "About",
+      aboutUs: "About Us",
+      news: "News",
+      contact: "Contact",
+      copyright: "© 2024 Fortia Administrative Law Office. All rights reserved."
+    }
+  };
+
+  const t = content[lang];
 
   return (
     <footer className="bg-gray-800 text-white py-12">
@@ -11,44 +54,44 @@ export default function UnifiedFooter() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Column 1: Office Information */}
           <div>
-            <Link href="/">
+            <Link href={`/${lang}`}>
               <h3 className="text-lg font-semibold mb-4 hover:text-gray-300 transition-colors cursor-pointer">
-                <span className="text-white">Fortia</span>
-                <span className="text-white ml-1">Administrative Law Office</span>
+                <span className="text-white">{t.companyName}</span>
+                <span className="text-white ml-1">{t.companyNameFull}</span>
               </h3>
             </Link>
             <div className="mb-4">
               <p className="text-gray-400">
                 〒100-0001<br />
-                1-1-1 Chiyoda, Chiyoda-ku, Tokyo<br />
+                {lang === 'ja' ? '東京都千代田区千代田1-1-1' : '1-1-1 Chiyoda, Chiyoda-ku, Tokyo'}<br />
                 TEL: 03-1234-5678
               </p>
             </div>
             <div className="mb-4">
-              <h4 className="text-sm font-semibold mb-2">Business Hours</h4>
+              <h4 className="text-sm font-semibold mb-2">{t.businessHours}</h4>
               <p className="text-gray-400 text-sm">
-                Weekdays: 9:00 - 18:00<br />
-                Saturday: 9:00 - 17:00<br />
-                Sunday & Holidays: Closed
+                {t.weekdays}<br />
+                {t.saturday}<br />
+                {t.holiday}
               </p>
             </div>
             <div>
-              <h4 className="text-sm font-semibold mb-2">Service Areas</h4>
+              <h4 className="text-sm font-semibold mb-2">{t.serviceAreas}</h4>
               <p className="text-gray-400 text-sm">
-                Tokyo, Chiba, Saitama, Kanagawa<br />
-                ※Other areas available upon consultation
+                {t.areasText}<br />
+                {t.otherAreas}
               </p>
             </div>
           </div>
 
           {/* Column 2: Services */}
           <div className="md:col-span-2">
-            <h3 className="text-lg font-semibold mb-4">Services</h3>
+            <h3 className="text-lg font-semibold mb-4">{t.services}</h3>
             <div className="md:columns-2 md:gap-x-6 space-y-2">
               {serviceCategories.map((category) => (
                 <div key={category.id} className="mb-2 break-inside-avoid">
                   <Link 
-                    href={`/services/${category.slug}`}
+                    href={`/${lang}/services/${category.slug}`}
                     className="text-gray-300 hover:text-white font-medium transition-colors block"
                   >
                     {category.title}
@@ -60,28 +103,28 @@ export default function UnifiedFooter() {
 
           {/* Column 3: Other Links */}
           <div>
-            <h3 className="text-lg font-semibold mb-4">About</h3>
+            <h3 className="text-lg font-semibold mb-4">{t.about}</h3>
             <ul className="space-y-2">
               <li>
-                <Link href="/about" className="text-gray-400 hover:text-white transition-colors">
-                  About Us
+                <Link href={`/${lang}/about`} className="text-gray-400 hover:text-white transition-colors">
+                  {t.aboutUs}
                 </Link>
               </li>
               <li>
-                <Link href="/news" className="text-gray-400 hover:text-white transition-colors">
-                  News
+                <Link href={`/${lang}/news`} className="text-gray-400 hover:text-white transition-colors">
+                  {t.news}
                 </Link>
               </li>
               <li>
-                <Link href="/contact" className="text-gray-400 hover:text-white transition-colors">
-                  Contact
+                <Link href={`/${lang}/contact`} className="text-gray-400 hover:text-white transition-colors">
+                  {t.contact}
                 </Link>
               </li>
             </ul>
           </div>
         </div>
         <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-          <p>&copy; 2024 Fortia Administrative Law Office. All rights reserved.</p>
+          <p>{t.copyright}</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
- ヒーローセクション: 背景を純色に変更、テキストを左揃えに
- ボタン配置: 無料相談・サービス内容ボタンを左寄せに
- 特徴カード: 高さを統一してレイアウト改善
- お知らせ: 横一列レイアウト（日付・カテゴリ・内容）
- フッター: 英語表記に完全変更

🤖 Generated with [Claude Code](https://claude.ai/code)