### PR TITLE
feat: 言語切り替えアイコンを地球儀に変更とスタッフAPI実装

### DIFF
--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -1,0 +1,15 @@
+import { getStaff } from '@/lib/sanity'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  try {
+    const staff = await getStaff()
+    return NextResponse.json(staff)
+  } catch (error) {
+    console.error('Error fetching staff:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch staff' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -29,7 +29,7 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
         aria-label="言語を選択"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.055 11H5a2 2 0 0 1 1.964 1.69l.393 2.36a2 2 0 0 0 1.962 1.95h.838c.632 0 1.253-.17 1.8-.476a2 2 0 0 0 1.035-1.35l.5-3a2 2 0 0 1 1.962-1.677h.838A2 2 0 0 0 17 8.99V7a2 2 0 0 0-2-2h-3.5a2 2 0 0 0-1.732 1H8a2 2 0 0 0-2 2v.09a2 2 0 0 1-.764 1.578L3.055 11z" />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
         </svg>
         <span className="text-sm font-medium">LANGUAGE</span>
         <svg className={`w-4 h-4 transform transition-transform ${isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -37,3 +37,23 @@ export async function getNewsBySlug(slug: string) {
   `, { slug })
 }
 
+// スタッフ取得用のクエリ
+export async function getStaff() {
+  return await client.fetch(`
+    *[_type == "staff" && isActive == true] | order(order asc) {
+      _id,
+      name,
+      nameRomaji,
+      position,
+      photo {
+        asset-> {
+          url
+        },
+        alt
+      },
+      introduction,
+      order
+    }
+  `)
+}
+


### PR DESCRIPTION
- LanguageSwitcherの言語アイコンを地球儀アイコンに変更
- スタッフデータ取得用のgetStaff関数をsanity.tsに追加
- /api/staff APIルートを新規作成
- SanityのスタッフスキーマとフロントエンドAPIが連携完了

🤖 Generated with [Claude Code](https://claude.ai/code)