### PR TITLE
feat: 事務所情報を最新の正確な内容に更新

### DIFF
--- a/src/app/[lang]/about/page.tsx
+++ b/src/app/[lang]/about/page.tsx
@@ -494,7 +494,7 @@ export default function About() {
           <h2 className="text-3xl font-bold text-gray-900 text-center mb-8">{t.accessInfo}</h2>
           <div className="bg-white rounded-lg shadow-sm overflow-hidden">
             <iframe
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d6502.435134159015!2d140.2966433!3d35.4246401!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x6022b90562f4a5a3%3A0xc335baa974e81428!2z44CSMjk3LTAwMjYg5Y2D6JGJ55yM6IyC5Y6f5biC6IyC5Y6f77yV77yX77yZ!5e0!3m2!1sja!2sjp!4v1752280876305!5m2!1sja!2sjp"
+              src="https://www.google.com/maps/embed/v1/place?key=AIzaSyBFw0Qbyq9zTFTd-tUY6dOdyR7rFhf3h3Y&q=〒297-0026+千葉県茂原市八千代2丁目6番地の13&zoom=16&language=ja"
               width="100%"
               height="450"
               style={{ border: 0 }}


### PR DESCRIPTION
- 名称: フォルティア行政書士事務所（変更なし）
- 設立: 2008年に変更（従来: 2014年）
- 代表者名: 鈴木 康嗣を追加
- 登録情報: 千葉県行政書士会所属 登録番号第08100026号に更新
- 所在地: 千葉県茂原市八千代2丁目6番地の13に変更
- 従業員数: 10名を追加
- 業務内容: ビザ申請、各種許認可申請、契約書作成、外国人材生活支援等を追加
- 認定: 法務省認定 登録支援機関認定：１９登－０００９１７を追加
- 関連会社: 株式会社World Wide Works、有限会社鈴木弥七商店を追加
- 連絡先: TEL/FAX番号とメールアドレスを正確な情報に更新
- タイムライン: 設立年を2008年に修正

🤖 Generated with [Claude Code](https://claude.ai/code)