### PR TITLE
feat: トップページ特徴セクションのカードデザインを更新

### DIFF
--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -262,13 +262,15 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.achievement.title}</h3>
-                  <p className="text-gray-600 mb-6 leading-relaxed flex-1">
-                    {t.features.achievement.description}
-                  </p>
+                  <div className="flex-1">
+                    <p className="text-gray-600 mb-6 leading-relaxed">
+                      {t.features.achievement.description}
+                    </p>
+                  </div>
                   {/* 薄い区切り線 */}
                   <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* 統計値表示エリア */}
-                  <div className="mt-auto">
+                  <div className="h-20 flex items-center">
                     <div className="flex justify-around text-center w-full">
                       <div>
                         <p className="text-3xl font-bold text-blue-600">10,000+</p>
@@ -299,14 +301,16 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.pricing.title}</h3>
-                  <p className="text-gray-600 mb-6 leading-relaxed flex-1">
-                    {t.features.pricing.description}
-                  </p>
+                  <div className="flex-1">
+                    <p className="text-gray-600 mb-6 leading-relaxed">
+                      {t.features.pricing.description}
+                    </p>
+                  </div>
                   {/* 薄い区切り線 */}
                   <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* ハイライトボックス */}
-                  <div className="mt-auto">
-                    <div className="bg-blue-50 rounded-lg p-4 text-center">
+                  <div className="h-20 flex items-center">
+                    <div className="bg-blue-50 rounded-lg p-4 text-center w-full">
                       <p className="text-blue-900 font-bold text-lg">{t.features.pricing.savings}</p>
                       <p className="text-blue-700 text-sm mt-1">{t.features.pricing.comparison}</p>
                     </div>
@@ -330,16 +334,18 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.multilingual.title}</h3>
-                  <p className="text-gray-600 mb-6 leading-relaxed flex-1">
-                    {t.features.multilingual.description}
-                  </p>
+                  <div className="flex-1">
+                    <p className="text-gray-600 mb-6 leading-relaxed">
+                      {t.features.multilingual.description}
+                    </p>
+                  </div>
                   {/* 薄い区切り線 */}
                   <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* 言語タグエリア */}
-                  <div className="mt-auto">
-                    <div className="grid grid-cols-3 gap-2">
+                  <div className="h-20 flex items-center">
+                    <div className="grid grid-cols-3 gap-2 w-full">
                       {languages[lang].map((language, index) => (
-                        <span key={index} className="px-2 py-1 bg-blue-600 text-white rounded text-sm font-medium text-center">
+                        <span key={index} className="px-2 py-1 bg-blue-50 text-blue-900 rounded text-sm font-medium text-center border border-blue-100">
                           {language}
                         </span>
                       ))}

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -265,14 +265,17 @@ export default async function Home({ params }: PageProps) {
                   <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.achievement.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4 mt-auto flex items-center">
+                  {/* 薄い区切り線 */}
+                  <div className="w-full h-px bg-gray-200 mb-6"></div>
+                  {/* 統計値表示エリア */}
+                  <div className="mt-auto">
                     <div className="flex justify-around text-center w-full">
                       <div>
-                        <p className="text-2xl font-bold text-blue-600">10,000+</p>
+                        <p className="text-3xl font-bold text-blue-600">10,000+</p>
                         <p className="text-sm text-gray-500 mt-1">{t.features.achievement.applications}</p>
                       </div>
                       <div>
-                        <p className="text-2xl font-bold text-blue-600">99%</p>
+                        <p className="text-3xl font-bold text-blue-600">99%</p>
                         <p className="text-sm text-gray-500 mt-1">{t.features.achievement.approvalRate}</p>
                       </div>
                     </div>
@@ -299,9 +302,14 @@ export default async function Home({ params }: PageProps) {
                   <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.pricing.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4 text-center mt-auto flex flex-col justify-center">
-                    <p className="text-blue-900 font-bold text-lg">{t.features.pricing.savings}</p>
-                    <p className="text-blue-700 text-sm mt-1">{t.features.pricing.comparison}</p>
+                  {/* 薄い区切り線 */}
+                  <div className="w-full h-px bg-gray-200 mb-6"></div>
+                  {/* ハイライトボックス */}
+                  <div className="mt-auto">
+                    <div className="bg-blue-50 rounded-lg p-4 text-center">
+                      <p className="text-blue-900 font-bold text-lg">{t.features.pricing.savings}</p>
+                      <p className="text-blue-700 text-sm mt-1">{t.features.pricing.comparison}</p>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -325,10 +333,13 @@ export default async function Home({ params }: PageProps) {
                   <p className="text-gray-600 mb-6 leading-relaxed flex-1">
                     {t.features.multilingual.description}
                   </p>
-                  <div className="bg-blue-50 rounded-lg p-4 mt-auto flex items-center">
-                    <div className="flex flex-wrap gap-2 justify-center w-full">
+                  {/* 薄い区切り線 */}
+                  <div className="w-full h-px bg-gray-200 mb-6"></div>
+                  {/* 言語タグエリア */}
+                  <div className="mt-auto">
+                    <div className="grid grid-cols-3 gap-2">
                       {languages[lang].map((language, index) => (
-                        <span key={index} className="px-3 py-1 bg-white text-blue-700 rounded-full text-sm font-medium border border-blue-200">
+                        <span key={index} className="px-2 py-1 bg-blue-600 text-white rounded text-sm font-medium text-center">
                           {language}
                         </span>
                       ))}


### PR DESCRIPTION
- 各カードの説明文と特徴表示エリアの間に薄いグレーの区切り線を追加
- 左カード: 統計値(10,000+, 99%)を背景なしで大きく表示
- 中央カード: ハイライトボックスのデザインを維持
- 右カード: 言語タグを3×3グリッドで青色背景の統一デザインに変更

🤖 Generated with [Claude Code](https://claude.ai/code)