### PR TITLE
fix: 多言語対応カードレイアウトとフッター情報を修正

### DIFF
--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -262,13 +262,13 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.achievement.title}</h3>
-                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '140px'}}>
-                    <p className="text-gray-600 leading-relaxed">
+                  <div className="flex-1">
+                    <p className="text-gray-600 leading-relaxed mb-6">
                       {t.features.achievement.description}
                     </p>
-                    {/* 薄い区切り線 */}
-                    <div className="w-full h-px bg-gray-200 my-4"></div>
                   </div>
+                  {/* 薄い区切り線 - 固定位置 */}
+                  <div className="w-full h-px bg-gray-200 mb-4"></div>
                   {/* 統計値表示エリア */}
                   <div className="h-20 flex items-center">
                     <div className="flex justify-around text-center w-full">
@@ -301,13 +301,13 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.pricing.title}</h3>
-                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '140px'}}>
-                    <p className="text-gray-600 leading-relaxed">
+                  <div className="flex-1">
+                    <p className="text-gray-600 leading-relaxed mb-6">
                       {t.features.pricing.description}
                     </p>
-                    {/* 薄い区切り線 */}
-                    <div className="w-full h-px bg-gray-200 my-4"></div>
                   </div>
+                  {/* 薄い区切り線 - 固定位置 */}
+                  <div className="w-full h-px bg-gray-200 mb-4"></div>
                   {/* ハイライトボックス */}
                   <div className="h-20 flex items-center">
                     <div className="bg-blue-50 rounded-lg p-4 text-center w-full">
@@ -334,13 +334,13 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.multilingual.title}</h3>
-                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '140px'}}>
-                    <p className="text-gray-600 leading-relaxed">
+                  <div className="flex-1">
+                    <p className="text-gray-600 leading-relaxed mb-6">
                       {t.features.multilingual.description}
                     </p>
-                    {/* 薄い区切り線 */}
-                    <div className="w-full h-px bg-gray-200 my-4"></div>
                   </div>
+                  {/* 薄い区切り線 - 固定位置 */}
+                  <div className="w-full h-px bg-gray-200 mb-4"></div>
                   {/* 言語タグエリア */}
                   <div className="h-20 flex items-center">
                     <div className="grid grid-cols-3 gap-2 w-full">

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -262,13 +262,13 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.achievement.title}</h3>
-                  <div className="flex-1">
-                    <p className="text-gray-600 mb-6 leading-relaxed">
+                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '120px'}}>
+                    <p className="text-gray-600 leading-relaxed">
                       {t.features.achievement.description}
                     </p>
+                    {/* 薄い区切り線 */}
+                    <div className="w-full h-px bg-gray-200 my-6"></div>
                   </div>
-                  {/* 薄い区切り線 */}
-                  <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* 統計値表示エリア */}
                   <div className="h-20 flex items-center">
                     <div className="flex justify-around text-center w-full">
@@ -301,13 +301,13 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.pricing.title}</h3>
-                  <div className="flex-1">
-                    <p className="text-gray-600 mb-6 leading-relaxed">
+                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '120px'}}>
+                    <p className="text-gray-600 leading-relaxed">
                       {t.features.pricing.description}
                     </p>
+                    {/* 薄い区切り線 */}
+                    <div className="w-full h-px bg-gray-200 my-6"></div>
                   </div>
-                  {/* 薄い区切り線 */}
-                  <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* ハイライトボックス */}
                   <div className="h-20 flex items-center">
                     <div className="bg-blue-50 rounded-lg p-4 text-center w-full">
@@ -334,13 +334,13 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.multilingual.title}</h3>
-                  <div className="flex-1">
-                    <p className="text-gray-600 mb-6 leading-relaxed">
+                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '120px'}}>
+                    <p className="text-gray-600 leading-relaxed">
                       {t.features.multilingual.description}
                     </p>
+                    {/* 薄い区切り線 */}
+                    <div className="w-full h-px bg-gray-200 my-6"></div>
                   </div>
-                  {/* 薄い区切り線 */}
-                  <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* 言語タグエリア */}
                   <div className="h-20 flex items-center">
                     <div className="grid grid-cols-3 gap-2 w-full">

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -262,12 +262,12 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.achievement.title}</h3>
-                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '120px'}}>
+                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '140px'}}>
                     <p className="text-gray-600 leading-relaxed">
                       {t.features.achievement.description}
                     </p>
                     {/* 薄い区切り線 */}
-                    <div className="w-full h-px bg-gray-200 my-6"></div>
+                    <div className="w-full h-px bg-gray-200 my-4"></div>
                   </div>
                   {/* 統計値表示エリア */}
                   <div className="h-20 flex items-center">
@@ -301,12 +301,12 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.pricing.title}</h3>
-                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '120px'}}>
+                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '140px'}}>
                     <p className="text-gray-600 leading-relaxed">
                       {t.features.pricing.description}
                     </p>
                     {/* 薄い区切り線 */}
-                    <div className="w-full h-px bg-gray-200 my-6"></div>
+                    <div className="w-full h-px bg-gray-200 my-4"></div>
                   </div>
                   {/* ハイライトボックス */}
                   <div className="h-20 flex items-center">
@@ -334,12 +334,12 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.multilingual.title}</h3>
-                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '120px'}}>
+                  <div className="flex-1 flex flex-col justify-between" style={{minHeight: '140px'}}>
                     <p className="text-gray-600 leading-relaxed">
                       {t.features.multilingual.description}
                     </p>
                     {/* 薄い区切り線 */}
-                    <div className="w-full h-px bg-gray-200 my-6"></div>
+                    <div className="w-full h-px bg-gray-200 my-4"></div>
                   </div>
                   {/* 言語タグエリア */}
                   <div className="h-20 flex items-center">

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -261,9 +261,12 @@ export default async function Home({ params }: PageProps) {
                   />
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
-                  <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.achievement.title}</h3>
+                  {/* タイトルエリア - 固定高 */}
+                  <div className="h-8 mb-4">
+                    <h3 className="text-xl font-semibold text-gray-900">{t.features.achievement.title}</h3>
+                  </div>
                   {/* 説明文エリア - 固定高 */}
-                  <div style={{height: '120px'}} className="mb-4">
+                  <div className="h-24 mb-6">
                     <p className="text-gray-600 leading-relaxed">
                       {t.features.achievement.description}
                     </p>
@@ -271,7 +274,7 @@ export default async function Home({ params }: PageProps) {
                   {/* 薄い区切り線 */}
                   <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* 統計値表示エリア */}
-                  <div className="h-20 flex items-center mt-auto">
+                  <div className="h-20 flex items-center">
                     <div className="flex justify-around text-center w-full">
                       <div>
                         <p className="text-3xl font-bold text-blue-600">10,000+</p>
@@ -301,9 +304,12 @@ export default async function Home({ params }: PageProps) {
                   />
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
-                  <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.pricing.title}</h3>
+                  {/* タイトルエリア - 固定高 */}
+                  <div className="h-8 mb-4">
+                    <h3 className="text-xl font-semibold text-gray-900">{t.features.pricing.title}</h3>
+                  </div>
                   {/* 説明文エリア - 固定高 */}
-                  <div style={{height: '120px'}} className="mb-4">
+                  <div className="h-24 mb-6">
                     <p className="text-gray-600 leading-relaxed">
                       {t.features.pricing.description}
                     </p>
@@ -311,7 +317,7 @@ export default async function Home({ params }: PageProps) {
                   {/* 薄い区切り線 */}
                   <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* ハイライトボックス */}
-                  <div className="h-20 flex items-center mt-auto">
+                  <div className="h-20 flex items-center">
                     <div className="bg-blue-50 rounded-lg p-4 text-center w-full">
                       <p className="text-blue-900 font-bold text-lg">{t.features.pricing.savings}</p>
                       <p className="text-blue-700 text-sm mt-1">{t.features.pricing.comparison}</p>
@@ -335,9 +341,12 @@ export default async function Home({ params }: PageProps) {
                   />
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
-                  <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.multilingual.title}</h3>
+                  {/* タイトルエリア - 固定高 */}
+                  <div className="h-8 mb-4">
+                    <h3 className="text-xl font-semibold text-gray-900">{t.features.multilingual.title}</h3>
+                  </div>
                   {/* 説明文エリア - 固定高 */}
-                  <div style={{height: '120px'}} className="mb-4">
+                  <div className="h-24 mb-6">
                     <p className="text-gray-600 leading-relaxed">
                       {t.features.multilingual.description}
                     </p>
@@ -345,7 +354,7 @@ export default async function Home({ params }: PageProps) {
                   {/* 薄い区切り線 */}
                   <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* 言語タグエリア */}
-                  <div className="h-20 flex items-center mt-auto">
+                  <div className="h-20 flex items-center">
                     <div className="grid grid-cols-3 gap-2 w-full">
                       {languages[lang].map((language, index) => (
                         <span key={index} className="px-2 py-1 bg-blue-50 text-blue-900 rounded text-sm font-medium text-center border border-blue-100">

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -262,15 +262,16 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.achievement.title}</h3>
-                  <div className="flex-1">
-                    <p className="text-gray-600 leading-relaxed mb-6">
+                  {/* 説明文エリア - 固定高 */}
+                  <div style={{height: '120px'}} className="mb-4">
+                    <p className="text-gray-600 leading-relaxed">
                       {t.features.achievement.description}
                     </p>
                   </div>
-                  {/* 薄い区切り線 - 固定位置 */}
-                  <div className="w-full h-px bg-gray-200 mb-4"></div>
+                  {/* 薄い区切り線 */}
+                  <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* 統計値表示エリア */}
-                  <div className="h-20 flex items-center">
+                  <div className="h-20 flex items-center mt-auto">
                     <div className="flex justify-around text-center w-full">
                       <div>
                         <p className="text-3xl font-bold text-blue-600">10,000+</p>
@@ -301,15 +302,16 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.pricing.title}</h3>
-                  <div className="flex-1">
-                    <p className="text-gray-600 leading-relaxed mb-6">
+                  {/* 説明文エリア - 固定高 */}
+                  <div style={{height: '120px'}} className="mb-4">
+                    <p className="text-gray-600 leading-relaxed">
                       {t.features.pricing.description}
                     </p>
                   </div>
-                  {/* 薄い区切り線 - 固定位置 */}
-                  <div className="w-full h-px bg-gray-200 mb-4"></div>
+                  {/* 薄い区切り線 */}
+                  <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* ハイライトボックス */}
-                  <div className="h-20 flex items-center">
+                  <div className="h-20 flex items-center mt-auto">
                     <div className="bg-blue-50 rounded-lg p-4 text-center w-full">
                       <p className="text-blue-900 font-bold text-lg">{t.features.pricing.savings}</p>
                       <p className="text-blue-700 text-sm mt-1">{t.features.pricing.comparison}</p>
@@ -334,15 +336,16 @@ export default async function Home({ params }: PageProps) {
                 </div>
                 <div className="p-6 flex-1 flex flex-col">
                   <h3 className="text-xl font-semibold mb-4 text-gray-900">{t.features.multilingual.title}</h3>
-                  <div className="flex-1">
-                    <p className="text-gray-600 leading-relaxed mb-6">
+                  {/* 説明文エリア - 固定高 */}
+                  <div style={{height: '120px'}} className="mb-4">
+                    <p className="text-gray-600 leading-relaxed">
                       {t.features.multilingual.description}
                     </p>
                   </div>
-                  {/* 薄い区切り線 - 固定位置 */}
-                  <div className="w-full h-px bg-gray-200 mb-4"></div>
+                  {/* 薄い区切り線 */}
+                  <div className="w-full h-px bg-gray-200 mb-6"></div>
                   {/* 言語タグエリア */}
-                  <div className="h-20 flex items-center">
+                  <div className="h-20 flex items-center mt-auto">
                     <div className="grid grid-cols-3 gap-2 w-full">
                       {languages[lang].map((language, index) => (
                         <span key={index} className="px-2 py-1 bg-blue-50 text-blue-900 rounded text-sm font-medium text-center border border-blue-100">

--- a/src/components/UnifiedFooter.tsx
+++ b/src/components/UnifiedFooter.tsx
@@ -29,7 +29,7 @@ export default function UnifiedFooter({ lang = 'ja' }: UnifiedFooterProps) {
     },
     en: {
       companyName: "Fortia",
-      companyNameFull: "Administrative Law Office",
+      companyNameFull: "Administrative Scrivener Office",
       businessHours: "Business Hours",
       weekdays: "Weekdays: 9:00 - 18:00",
       saturday: "Saturday: 9:00 - 17:00",
@@ -42,7 +42,7 @@ export default function UnifiedFooter({ lang = 'ja' }: UnifiedFooterProps) {
       aboutUs: "About Us",
       news: "News",
       contact: "Contact",
-      copyright: "© 2024 Fortia Administrative Law Office. All rights reserved."
+      copyright: "© 2024 Fortia Administrative Scrivener Office. All rights reserved."
     }
   };
 
@@ -62,9 +62,10 @@ export default function UnifiedFooter({ lang = 'ja' }: UnifiedFooterProps) {
             </Link>
             <div className="mb-4">
               <p className="text-gray-400">
-                〒100-0001<br />
-                {lang === 'ja' ? '東京都千代田区千代田1-1-1' : '1-1-1 Chiyoda, Chiyoda-ku, Tokyo'}<br />
-                TEL: 03-1234-5678
+                〒297-0026<br />
+                {lang === 'ja' ? '千葉県茂原市八千代2丁目6番地の13' : '2-6-13 Yachiyo, Mobara-shi, Chiba 297-0026'}<br />
+                TEL: 0475-22-8741<br />
+                FAX: 0475-22-8742
               </p>
             </div>
             <div className="mb-4">


### PR DESCRIPTION
- 特徴カードの薄い線の高さを統一するため、説明文エリアの最小高さを設定
- 日本語/英語の文字量の違いに関係なく、3つのカードで線の位置が揃うよう調整
- フッターの英語社名をヘッダーと統一("Administrative Scrivener Office")
- フッター住所を実際の事務所住所(茂原市八千代)に更新
- FAX番号も追加して会社情報ページと統一

🤖 Generated with [Claude Code](https://claude.ai/code)