### PR TITLE
feat: 言語切り替えをホバーで開くように変更

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -22,9 +22,12 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
   }
 
   return (
-    <div className="relative">
+    <div 
+      className="relative"
+      onMouseEnter={() => setIsOpen(true)}
+      onMouseLeave={() => setIsOpen(false)}
+    >
       <button
-        onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-2 px-3 py-2 text-gray-600 hover:text-gray-900 transition-colors"
         aria-label="言語を選択"
       >
@@ -41,7 +44,7 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
         <div className="absolute right-0 mt-1 w-32 bg-white border border-gray-200 rounded-md shadow-lg z-50">
           <div className="py-1">
             <button
-              onClick={() => handleLanguageChange('en')}
+              onMouseDown={() => handleLanguageChange('en')}
               className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 transition-colors ${
                 currentLang === 'en' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-700'
               }`}
@@ -49,7 +52,7 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
               English
             </button>
             <button
-              onClick={() => handleLanguageChange('ja')}
+              onMouseDown={() => handleLanguageChange('ja')}
               className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-100 transition-colors ${
                 currentLang === 'ja' ? 'bg-blue-50 text-blue-600 font-medium' : 'text-gray-700'
               }`}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { Locale } from '@/lib/i18n/types'
 import { getLocalizedPath, getPathWithoutLocale } from '@/lib/i18n/utils'
@@ -11,6 +11,7 @@ interface LanguageSwitcherProps {
 
 export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const pathname = usePathname()
   const router = useRouter()
 
@@ -21,11 +22,25 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
     setIsOpen(false)
   }
 
+  const handleMouseEnter = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+    setIsOpen(true)
+  }
+
+  const handleMouseLeave = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsOpen(false)
+    }, 200) // 200ms遅延
+  }
+
   return (
     <div 
       className="relative"
-      onMouseEnter={() => setIsOpen(true)}
-      onMouseLeave={() => setIsOpen(false)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       <button
         className="flex items-center gap-2 px-3 py-2 text-gray-600 hover:text-gray-900 transition-colors"
@@ -41,7 +56,7 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
       </button>
       
       {isOpen && (
-        <div className="absolute right-0 mt-1 w-32 bg-white border border-gray-200 rounded-md shadow-lg z-50">
+        <div className="absolute right-0 top-full w-32 bg-white border border-gray-200 rounded-md shadow-lg z-50">
           <div className="py-1">
             <button
               onMouseDown={() => handleLanguageChange('en')}


### PR DESCRIPTION
- onMouseEnter/onMouseLeaveでドロップダウンメニューの開閉を制御
- クリック不要でカーソルを合わせるだけで言語選択が可能
- onMouseDownでより直感的な選択操作を実現
- UXを向上させ、より迅速な言語切り替えを提供

🤖 Generated with [Claude Code](https://claude.ai/code)