### PR TITLE
feat: ニュースセクションの多言語対応を実装

### DIFF
--- a/sanity/schemaTypes/news.ts
+++ b/sanity/schemaTypes/news.ts
@@ -6,9 +6,16 @@ export default defineType({
   title: 'お知らせ',
   type: 'document',
   fields: [
+    // 日本語フィールド
     defineField({
       name: 'title',
-      title: 'タイトル',
+      title: 'タイトル（日本語）',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'titleEn',
+      title: 'タイトル（英語）',
       type: 'string',
       validation: (rule) => rule.required(),
     }),
@@ -30,14 +37,26 @@ export default defineType({
     }),
     defineField({
       name: 'excerpt',
-      title: '概要',
+      title: '概要（日本語）',
+      type: 'text',
+      rows: 3,
+    }),
+    defineField({
+      name: 'excerptEn',
+      title: '概要（英語）',
       type: 'text',
       rows: 3,
     }),
     defineField({
       name: 'content',
-      title: '本文',
+      title: '本文（日本語）',
       description: 'ブログのようなリッチな本文を記載できます',
+      ...richContentArray,
+    }),
+    defineField({
+      name: 'contentEn',
+      title: '本文（英語）',
+      description: 'Rich content for English version',
       ...richContentArray,
     }),
     defineField({
@@ -51,13 +70,14 @@ export default defineType({
   preview: {
     select: {
       title: 'title',
+      titleEn: 'titleEn',
       subtitle: 'publishedAt',
       media: 'mainImage',
     },
     prepare(selection) {
-      const {title, subtitle} = selection
+      const {title, titleEn, subtitle} = selection
       return {
-        title,
+        title: `${title} / ${titleEn || 'No English title'}`,
         subtitle: subtitle ? new Date(subtitle).toLocaleDateString('ja-JP') : '日付未設定',
       }
     },

--- a/src/app/[lang]/news/page.tsx
+++ b/src/app/[lang]/news/page.tsx
@@ -13,9 +13,11 @@ type CategoryKey = 'business_notice' | 'new_services' | 'legal_update' | 'price_
 interface News {
   _id: string;
   title: string;
+  titleEn?: string;
   slug: { current: string };
   publishedAt: string;
   excerpt?: string;
+  excerptEn?: string;
   category?: CategoryKey;
   featured?: boolean;
 }
@@ -93,13 +95,13 @@ export default async function NewsPage({ params }: PageProps) {
               {news.map((item) => (
                 <li key={item._id}>
                   <Link 
-                    href={`/news/${item.slug.current}`}
+                    href={`/${lang}/news/${item.slug.current}`}
                     className="block px-6 py-4 hover:bg-gray-50 transition-colors"
                   >
                     <div className="flex items-center gap-4">
                       {/* 日付 */}
                       <time className="text-sm text-gray-500 whitespace-nowrap">
-                        {new Date(item.publishedAt).toLocaleDateString('ja-JP')}
+                        {new Date(item.publishedAt).toLocaleDateString(lang === 'ja' ? 'ja-JP' : 'en-US')}
                       </time>
                       
                       {/* カテゴリラベル */}
@@ -113,7 +115,7 @@ export default async function NewsPage({ params }: PageProps) {
                       
                       {/* タイトル */}
                       <h3 className="flex-1 text-gray-900 hover:text-blue-600 transition-colors">
-                        {item.title}
+                        {lang === 'ja' ? item.title : (item.titleEn || item.title)}
                       </h3>
                     </div>
                   </Link>

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -13,9 +13,11 @@ export async function getNews() {
     *[_type == "news"] | order(publishedAt desc) {
       _id,
       title,
+      titleEn,
       slug,
       publishedAt,
       excerpt,
+      excerptEn,
       category
     }
   `)
@@ -27,10 +29,13 @@ export async function getNewsBySlug(slug: string) {
     *[_type == "news" && slug.current == $slug][0] {
       _id,
       title,
+      titleEn,
       slug,
       publishedAt,
       excerpt,
+      excerptEn,
       content,
+      contentEn,
       category,
       featured
     }


### PR DESCRIPTION
- Sanityニューススキーマに英語フィールドを追加（titleEn, excerptEn, contentEn）
- ニュース一覧ページで言語に応じたタイトル表示に対応
- ニュース詳細ページの完全多言語対応（パンくずナビ、コンテンツ、ナビゲーション）
- Sanityクエリに英語フィールドを追加
- 日英両言語でのカテゴリマッピングとUI表示対応

🤖 Generated with [Claude Code](https://claude.ai/code)