### PR TITLE
fix: モバイル版ヘッダーレイアウト改善

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -69,9 +69,9 @@ export default function Header({ lang }: HeaderProps) {
       <header className="fixed top-0 left-0 right-0 bg-white shadow-sm z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
-            <div className="flex items-center">
-              <Link href={`${basePath}/`} className="hover:opacity-80 transition-opacity">
-                <h1 className="text-base sm:text-lg lg:text-xl font-bold">
+            <div className="flex items-center flex-1 min-w-0">
+              <Link href={`${basePath}/`} className="hover:opacity-80 transition-opacity min-w-0">
+                <h1 className="text-sm sm:text-base lg:text-lg xl:text-xl font-bold">
                   <span className="text-gray-600">{t.companyName}</span>
                   <span className="text-gray-600 ml-1 hidden sm:inline whitespace-nowrap">{t.companyNameFull}</span>
                   <span className="text-gray-600 ml-1 sm:hidden whitespace-nowrap">{t.companyNameShort}</span>
@@ -100,7 +100,7 @@ export default function Header({ lang }: HeaderProps) {
             </nav>
             
             {/* モバイルメニュー */}
-            <div className="flex items-center gap-3 md:hidden">
+            <div className="flex items-center gap-1 sm:gap-2 md:hidden flex-shrink-0">
               <LanguageSwitcher currentLang={lang} />
               <MobileMenu lang={lang} />
             </div>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -15,6 +15,15 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
   const pathname = usePathname()
   const router = useRouter()
 
+  // 言語コードマッピング
+  const langCodeMap: Record<Locale, string> = {
+    'ja': 'JA',
+    'en': 'EN',
+    'zh-CN': '中',
+    'zh-TW': '繁',
+    'vi': 'VI'
+  }
+
   const handleLanguageChange = (newLang: Locale) => {
     const pathWithoutLocale = getPathWithoutLocale(pathname)
     const newPath = getLocalizedPath(pathWithoutLocale, newLang)
@@ -43,14 +52,21 @@ export default function LanguageSwitcher({ currentLang }: LanguageSwitcherProps)
       onMouseLeave={handleMouseLeave}
     >
       <button
-        className="flex items-center gap-2 px-3 py-2 text-gray-600 hover:text-gray-900 transition-colors"
+        className="flex items-center gap-1 sm:gap-2 px-2 sm:px-3 py-2 text-gray-600 hover:text-gray-900 transition-colors"
         aria-label="言語を選択"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        {/* モバイル版：🌐 + 言語コード */}
+        <span className="text-base md:hidden">🌐</span>
+        <span className="text-xs font-medium md:hidden">{langCodeMap[currentLang]}</span>
+        
+        {/* デスクトップ版：従来のデザイン */}
+        <svg className="w-4 h-4 hidden md:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
         </svg>
-        <span className="text-sm font-medium">LANGUAGE</span>
-        <svg className={`w-4 h-4 transform transition-transform ${isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <span className="text-sm font-medium hidden md:inline">LANGUAGE</span>
+        
+        {/* ドロップダウンアイコン */}
+        <svg className={`w-3 h-3 sm:w-4 sm:h-4 transform transition-transform ${isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>


### PR DESCRIPTION
- LanguageSwitcher: モバイル版で🌐アイコン + 言語コード表示に変更
  - デスクトップ版は従来の「LANGUAGE」表示を維持
  - 言語コードマッピング: JA/EN/中/繁/VI
- Header: 社名の折り返しを防ぐレイアウト調整
  - flex-1 min-w-0でコンテナ最適化
  - 文字サイズをより小さく調整 (text-sm sm:text-base)
  - モバイルメニューのgap調整 (gap-1 sm:gap-2)

🤖 Generated with [Claude Code](https://claude.ai/code)