### PR TITLE
feat: Google Tag Manager統合

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -90,9 +90,30 @@ export default async function RootLayout({ children, params }: Props) {
   
   return (
     <html lang={lang}>
+      <head>
+        {/* Google Tag Manager */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5LGKR992');`,
+          }}
+        />
+      </head>
       <body
         className={`${fontClass} antialiased`}
       >
+        {/* Google Tag Manager (noscript) */}
+        <noscript>
+          <iframe 
+            src="https://www.googletagmanager.com/ns.html?id=GTM-5LGKR992"
+            height="0" 
+            width="0" 
+            style={{ display: 'none', visibility: 'hidden' }}
+          />
+        </noscript>
         {children}
       </body>
     </html>


### PR DESCRIPTION
- layout.tsxにGTMスクリプトを追加
- headセクションとbodyセクションに対応コードを埋め込み
- GTM ID: GTM-5LGKR992

🤖 Generated with [Claude Code](https://claude.ai/code)