### PR TITLE
fix: canonical URL重複問題の修正

### DIFF
--- a/src/app/[lang]/about/layout.tsx
+++ b/src/app/[lang]/about/layout.tsx
@@ -1,0 +1,81 @@
+import { Metadata } from 'next';
+import { Locale } from '@/lib/i18n/types';
+
+interface LayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ lang: Locale }>;
+}
+
+export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
+  const { lang } = await params;
+  
+  const metaContent = {
+    ja: {
+      title: '事務所概要 | フォルティア行政書士事務所',
+      description: 'フォルティア行政書士事務所の概要、代表挨拶、スタッフ紹介、アクセス情報をご案内します。',
+    },
+    en: {
+      title: 'About Us | Fortia Administrative Law Office',
+      description: 'Learn about Fortia Administrative Law Office, our CEO message, staff introduction, and access information.',
+    },
+    'zh-CN': {
+      title: '事务所概要 | Fortia行政书士事务所',
+      description: 'Fortia行政书士事务所的概要、代表致词、员工介绍、交通信息指南。',
+    },
+    'zh-TW': {
+      title: '事務所概要 | Fortia行政書士事務所',
+      description: 'Fortia行政書士事務所的概要、代表致詞、員工介紹、交通資訊指南。',
+    },
+    vi: {
+      title: 'Giới thiệu | Văn phòng Hành chính Fortia',
+      description: 'Tìm hiểu về Văn phòng Hành chính Fortia, lời chào từ CEO, giới thiệu nhân viên và thông tin truy cập.',
+    },
+  };
+
+  const baseUrl = 'https://fortia-office.com';
+  const currentMeta = metaContent[lang] || metaContent.ja;
+
+  return {
+    title: currentMeta.title,
+    description: currentMeta.description,
+    alternates: {
+      canonical: `${baseUrl}/ja/about`, // Always use Japanese version as canonical
+      languages: {
+        'ja': `${baseUrl}/ja/about`,
+        'en': `${baseUrl}/en/about`,
+        'zh-CN': `${baseUrl}/zh-CN/about`,
+        'zh-TW': `${baseUrl}/zh-TW/about`,
+        'vi': `${baseUrl}/vi/about`,
+        'x-default': `${baseUrl}/ja/about`, // Set Japanese as default
+      },
+    },
+    openGraph: {
+      title: currentMeta.title,
+      description: currentMeta.description,
+      url: `${baseUrl}/${lang}/about`,
+      siteName: 'フォルティア行政書士事務所',
+      locale: lang === 'ja' ? 'ja_JP' : lang === 'en' ? 'en_US' : lang === 'zh-CN' ? 'zh_CN' : lang === 'zh-TW' ? 'zh_TW' : 'vi_VN',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: currentMeta.title,
+      description: currentMeta.description,
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-video-preview': -1,
+        'max-image-preview': 'large',
+        'max-snippet': -1,
+      },
+    },
+  };
+}
+
+export default function AboutLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/[lang]/contact/layout.tsx
+++ b/src/app/[lang]/contact/layout.tsx
@@ -39,13 +39,14 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
     title: currentMeta.title,
     description: currentMeta.description,
     alternates: {
-      canonical: `${baseUrl}/${lang}/contact`,
+      canonical: `${baseUrl}/ja/contact`, // Always use Japanese version as canonical
       languages: {
         'ja': `${baseUrl}/ja/contact`,
         'en': `${baseUrl}/en/contact`,
         'zh-CN': `${baseUrl}/zh-CN/contact`,
         'zh-TW': `${baseUrl}/zh-TW/contact`,
         'vi': `${baseUrl}/vi/contact`,
+        'x-default': `${baseUrl}/ja/contact`, // Set Japanese as default
       },
     },
     openGraph: {

--- a/src/app/[lang]/features/page.tsx
+++ b/src/app/[lang]/features/page.tsx
@@ -471,13 +471,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     title: currentMeta.title,
     description: currentMeta.description,
     alternates: {
-      canonical: `${baseUrl}/${lang}/features`,
+      canonical: `${baseUrl}/ja/features`, // Always use Japanese version as canonical
       languages: {
         'ja': `${baseUrl}/ja/features`,
         'en': `${baseUrl}/en/features`,
         'zh-CN': `${baseUrl}/zh-CN/features`,
         'zh-TW': `${baseUrl}/zh-TW/features`,
         'vi': `${baseUrl}/vi/features`,
+        'x-default': `${baseUrl}/ja/features`, // Set Japanese as default
       },
     },
     openGraph: {

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -75,13 +75,14 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: Loc
     description: metadata[lang].description,
     metadataBase: new URL(baseUrl),
     alternates: {
-      canonical: `${baseUrl}/${lang}`,
+      canonical: `${baseUrl}/ja`, // Always use Japanese version as canonical
       languages: {
         'ja': `${baseUrl}/ja`,
         'en': `${baseUrl}/en`,
         'zh-CN': `${baseUrl}/zh-CN`,
         'zh-TW': `${baseUrl}/zh-TW`,
         'vi': `${baseUrl}/vi`,
+        'x-default': `${baseUrl}/ja`, // Set Japanese as default
       },
     },
     openGraph: {

--- a/src/app/[lang]/news/page.tsx
+++ b/src/app/[lang]/news/page.tsx
@@ -144,13 +144,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     title: currentMeta.title,
     description: currentMeta.description,
     alternates: {
-      canonical: `${baseUrl}/${lang}/news`,
+      canonical: `${baseUrl}/ja/news`, // Always use Japanese version as canonical
       languages: {
         'ja': `${baseUrl}/ja/news`,
         'en': `${baseUrl}/en/news`,
         'zh-CN': `${baseUrl}/zh-CN/news`,
         'zh-TW': `${baseUrl}/zh-TW/news`,
         'vi': `${baseUrl}/vi/news`,
+        'x-default': `${baseUrl}/ja/news`, // Set Japanese as default
       },
     },
     openGraph: {

--- a/src/app/[lang]/services/page.tsx
+++ b/src/app/[lang]/services/page.tsx
@@ -82,13 +82,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     title: currentMeta.title,
     description: currentMeta.description,
     alternates: {
-      canonical: `${baseUrl}/${lang}/services`,
+      canonical: `${baseUrl}/ja/services`, // Always use Japanese version as canonical
       languages: {
         'ja': `${baseUrl}/ja/services`,
         'en': `${baseUrl}/en/services`,
         'zh-CN': `${baseUrl}/zh-CN/services`,
         'zh-TW': `${baseUrl}/zh-TW/services`,
         'vi': `${baseUrl}/vi/services`,
+        'x-default': `${baseUrl}/ja/services`, // Set Japanese as default
       },
     },
     openGraph: {


### PR DESCRIPTION
Google Search Consoleの「代替ページ（適切な canonical タグあり）」エラー対応

## 変更内容
- 全ページで日本語版をcanonical URLとして統一設定
- x-defaultタグに日本語版を設定
- aboutページ用のlayout.tsxを新規作成
- contact, features, news, servicesページのcanonical設定を更新

## 影響範囲
- /[lang]/layout.tsx
- /[lang]/about/layout.tsx (新規作成)
- /[lang]/contact/layout.tsx
- /[lang]/features/page.tsx
- /[lang]/news/page.tsx
- /[lang]/services/page.tsx

これにより、複数言語版が存在するページで日本語版が正規URLとして認識され、
他の言語版は代替ページとして適切に処理されます。