### PR TITLE
fix: 郵便番号を297-0026から297-0024に修正

### DIFF
--- a/src/app/[lang]/about/page.tsx
+++ b/src/app/[lang]/about/page.tsx
@@ -421,7 +421,7 @@ export default function About() {
                   <div>
                     <h3 className="text-base sm:text-lg font-semibold mb-1 sm:mb-2">{t.address}</h3>
                     <p className="text-sm sm:text-base text-gray-700 leading-relaxed">
-                      〒297-0026<br />
+                      〒297-0024<br />
                       千葉県茂原市八千代2丁目6番地の13
                     </p>
                   </div>
@@ -514,7 +514,7 @@ export default function About() {
           </div>
           <div className="mt-4 sm:mt-6 text-center">
             <p className="text-gray-700 text-sm sm:text-base lg:text-lg">
-              〒297-0026 千葉県茂原市八千代2丁目6番地の13
+              〒297-0024 千葉県茂原市八千代2丁目6番地の13
             </p>
             <p className="text-xs sm:text-sm text-gray-500 mt-2">
               ※ {lang === 'ja' ? '地図の左下にあるストリートビュー画像をクリックすると360度ビューに切り替わります' : 

--- a/src/app/[lang]/contact/page.tsx
+++ b/src/app/[lang]/contact/page.tsx
@@ -508,7 +508,7 @@ export default function Contact() {
                   <h3 className="text-lg sm:text-xl font-semibold mb-3 sm:mb-4">{t.officeAddress}</h3>
                   <div className="space-y-2">
                     <p className="text-gray-700">
-                      〒297-0026<br />
+                      〒297-0024<br />
                       千葉県茂原市八千代2丁目6番地の13
                     </p>
                     <p className="text-sm text-gray-600">

--- a/src/app/[lang]/services/[category]/page.tsx
+++ b/src/app/[lang]/services/[category]/page.tsx
@@ -69,7 +69,7 @@ export default async function CategoryPage({ params }: Props) {
           streetAddress: '茂原579',
           addressLocality: '茂原市',
           addressRegion: '千葉県',
-          postalCode: '297-0026',
+          postalCode: '297-0024',
           addressCountry: 'JP'
         }
       },

--- a/src/components/UnifiedFooter.tsx
+++ b/src/components/UnifiedFooter.tsx
@@ -108,8 +108,8 @@ export default function UnifiedFooter({ lang = 'ja' }: UnifiedFooterProps) {
             </Link>
             <div className="mb-3 sm:mb-4">
               <p className="text-gray-400 text-sm sm:text-base">
-                〒297-0026<br />
-                {lang === 'ja' ? '千葉県茂原市八千代2丁目6番地の13' : '2-6-13 Yachiyo, Mobara-shi, Chiba 297-0026'}<br />
+                〒297-0024<br />
+                {lang === 'ja' ? '千葉県茂原市八千代2丁目6番地の13' : '2-6-13 Yachiyo, Mobara-shi, Chiba 297-0024'}<br />
                 TEL: 070-5462-6133
               </p>
             </div>


### PR DESCRIPTION
- UnifiedFooter.tsx: フッターの住所表示を修正
- about/page.tsx: 事務所案内ページの住所を修正（2箇所）
- contact/page.tsx: お問い合わせページの住所を修正
- services/[category]/page.tsx: 構造化データの郵便番号を修正